### PR TITLE
mirror function to synchronize local files/folders with remote files/categories

### DIFF
--- a/cashctrl_api/api_client.py
+++ b/cashctrl_api/api_client.py
@@ -87,8 +87,11 @@ class CashCtrlAPIClient:
         if remote_name is None: remote_name = mypath.name
         if mime_type is None: mime_type = guess_type(mypath)[0]
 
-        # step (1/3): prepare
-        myfilelist = [{"mimeType": mime_type, "name": remote_name}]
+        # step (1/3: prepare)
+        if remote_category is None:
+            myfilelist = [{"mimeType": mime_type, "name": remote_name}]
+        else:
+            myfilelist = [{"mimeType": mime_type, "name": remote_name, 'categoryId': remote_category}]
         response = self.post("file/prepare.json", params={'files': myfilelist})
         myid = response['data'][0]['fileId']
         write_url = response['data'][0]['writeUrl']

--- a/cashctrl_api/api_client.py
+++ b/cashctrl_api/api_client.py
@@ -136,6 +136,7 @@ class CashCtrlAPIClient:
 
         data = self.get(f"{object}/category/tree.json")['data']
         df = pd.DataFrame(flatten_data(data.copy()))
+        df['level'] = df['path'].apply(lambda x: x.count(('/') - 1))
         if not system:
             df = df.loc[~df['isSystem'], :]
         return df.sort_values('path')

--- a/cashctrl_api/api_client.py
+++ b/cashctrl_api/api_client.py
@@ -151,3 +151,151 @@ class CashCtrlAPIClient:
         if not system:
             df = df.loc[~df['isSystem'], :]
         return df.sort_values('path')
+
+def _remote_filepath_list(self):
+    """
+    Get a table with all files incl. path (i.e. category) from the server.
+    Columns: id, catid, filename, path, rootpath, mimetype, size, ctime, mtime
+    """
+    xcat = self.list_categories('file')
+    xcat.rename(columns={'id': 'catId'}, inplace=True)
+
+    xfile = pd.DataFrame(self.get("file/list.json")['data'])
+    xfile = xfile[['id', 'categoryId', 'name', 'mimeType', 'size', 'created', 'lastUpdated']]
+    xfile = xfile.sort_values(['categoryId', 'name'])
+
+    merged_df = pd.merge(xfile, xcat[['catId', 'text', 'path']], left_on='categoryId', right_on='catId', how='left')
+    merged_df['path'] = merged_df['path'] + '/' + merged_df['name']
+    merged_df.drop(['text', 'catId'], axis=1, inplace=True)
+    merged_df.rename(columns={'name': 'filename'}, inplace=True)
+    merged_df.rename(columns={'categoryId': 'catid'}, inplace=True)
+    merged_df.rename(columns={'mimeType': 'mimetype'}, inplace=True)
+    merged_df.rename(columns={'created': 'ctime'}, inplace=True)
+    merged_df.rename(columns={'lastUpdated': 'mtime'}, inplace=True)
+    merged_df = merged_df[['id', 'catid', 'filename', 'path', 'mimetype', 'size', 'ctime', 'mtime' ]]
+
+    # check path and replace 'All files' with 'ROOT'
+    if not merged_df['path'].str.startswith('/All files').all():
+        raise Exception("path does not start with '/All files'")
+    merged_df['rootpath'] = merged_df['path'].str.replace('/All files', '/ROOT', regex=False)
+    merged_df = merged_df[['id', 'catid', 'filename', 'path', 'rootpath', 'mimetype', 'size', 'ctime', 'mtime' ]]
+    return merged_df
+
+def _local_filepath_list(self, root):
+    """
+    Get a table with all files incl. path from the root folder, skip hidden files.
+    Columns: filename, path, rootpath, mimetype, size, ctime, mtime
+    """
+
+    def _stat_to_json(file):
+        """from : https://stackoverflow.com/a/58684090/9770860"""
+        stat = file.stat()
+        attributes = {k[3:]: getattr(stat, k) for k in dir(stat) if k.startswith('st_')}
+        return {'file': str(file)} | attributes
+
+    rootpath = Path(root).expanduser()
+    files = [file for file in rootpath.rglob("*") if (file.is_file()) and (file.name[0] != '.')]
+    df = pd.DataFrame([_stat_to_json(file) for file in files])
+    df['ctime'] = pd.to_datetime(df['ctime_ns'], unit='ns').dt.tz_localize('UTC')
+    df['mtime'] = pd.to_datetime(df['mtime_ns'], unit='ns').dt.tz_localize('UTC')
+    df.rename(columns={'file': 'path'}, inplace=True)
+
+    if not df['path'].str.startswith(str(rootpath)).all():
+        raise Exception(f"path does not start with '{rootpath}'")
+    df['filename'] = df['path'].apply(lambda x: Path(x).name)
+    df['rootpath'] = df['path'].str.replace(str(rootpath), '/ROOT', regex=False)
+    df['mimetype'] = df['path'].apply(lambda x: guess_type(x)[0])
+    df = df[['filename', 'path', 'rootpath', 'mimetype', 'size', 'ctime', 'mtime']]
+    return df
+
+def _mirror_file_categories(self, local_files, remote_categories):
+    local_folders = local_files['rootpath'].str.replace('/[^/]*$', '', regex=True).unique()
+    local_folders = pd.DataFrame({'rootpath': local_folders}) # need a DataFrame for 'isin' set comparison
+
+    ## step 1: erase orphaned nodes (path does not appear in any file path)
+    ##         (IMPORTANT: trash must be empty as those files prevent category deletion)
+
+    is_orphaned = [not any(local_files['rootpath'].str.startswith(node)) for node in remote_categories['rootpath']]
+    orphaned = remote_categories.loc[is_orphaned,:].sort_values(by=['level', 'rootpath'], ascending = [False, False])
+    delete_ids = ','.join(orphaned['id'].astype(str))
+    if delete_ids != '': self.post("file/category/delete.json", params={'ids': delete_ids})
+
+    ## step 2: add required categories
+
+    # use the non-orphaned categories (orphaned ones have just been deleted above...)
+    non_orphaned = [not x for x in is_orphaned]
+    remote_categories = remote_categories.loc[non_orphaned,:]
+    remote_categories_map = {k: v for k, v in zip(remote_categories['rootpath'], remote_categories['id'])}
+
+    # which categories are missing?
+    missing_category_idx = ~local_folders['rootpath'].isin(remote_categories['rootpath'])
+    missing_categories = local_folders[missing_category_idx]
+
+    # create missing categories (work from root to leaf)
+    for category in missing_categories['rootpath']:
+        category = category.lstrip('/')
+        nodes = category.split('/')
+        if nodes[0] != 'ROOT': raise Exception("'ROOT' node missing")
+        # handle the 'nodes' of a single rootpath (from root to leaf)
+        for i in range(1, len(nodes)):
+            node_path = '/' + '/'.join(nodes[:(i+1)])
+            if node_path == '/ROOT': continue
+            parent_path = '/' + '/'.join(nodes[:i])
+            # check remote_categories_map, node could have been added by another rootpath
+            if not node_path in remote_categories_map:
+                if parent_path == '/ROOT':
+                    parentid = 0
+                else:
+                    parentid = remote_categories_map[parent_path]
+                # create category for real and add to the map
+                response = self.post("file/category/create.json", params={'name': nodes[i], 'parentId': parentid})
+                new_nodeid = response['insertId']
+                remote_categories_map[node_path] = new_nodeid
+
+
+def mirror_files(self, root):
+
+    ## 1. Preparation (get remote/local files in uniform structure)
+
+    remote_files = _remote_filepath_list(self)
+    # rf = remote_files; print(rf); print(""); print(rf.iloc[0]); print(""); print(rf.iloc[0]['path'])
+    local_files = _local_filepath_list(self, root)
+    # lf = local_files; print(lf); print(""); print(lf.iloc[0]); print(""); print(lf.iloc[0]['path'])
+
+    ## 2. File Deletion
+
+    to_delete = ~remote_files['rootpath'].isin(local_files['rootpath'])
+    if sum(to_delete) > 0:
+        delidx = remote_files[to_delete]['id']
+        # delete remote files, possibly orphaned folders/categories remain
+        myids = ','.join(delidx.astype(str))
+        self.post("file/delete.json", params={'ids': myids, 'force': True})
+        remote_files = remote_files.loc[~to_delete,:]
+
+    ## 3. Folder/Category Sync
+
+    # Trash/Papierkorb *MUST* be empty. Trashed files might still belong
+    # to a category and would prevent the deletion of an 'empty' category
+    self.post("file/empty_archive.json")
+
+    remote_categories = self.list_categories('file')
+    _mirror_file_categories(self, local_files, remote_categories)
+
+    ## 4.  Upload new or modified files
+
+    # fetch categories again and compare local/remote file
+    remote_categories = self.list_categories('file')
+    remote_file_exists = local_files['rootpath'].isin(remote_files['rootpath'])
+    remote_file_missing = [not x for x in remote_file_exists]
+
+    # upload missing files
+    uploads = local_files.loc[remote_file_missing]
+    for row in uploads.to_dict('records'):
+        papath = Path(row['rootpath']).parent
+        catid = remote_categories.loc[remote_categories['rootpath'] == str(papath)]['id'].item()
+        response = self.file_upload(row['path'], row['filename'], remote_category=catid)
+
+    # TODO: handle modified files (mtime of local file after mtime of remote file)
+    # FIXME:
+    # - need 'POST /api/v1/file/update.json' (https://app.cashctrl.com/static/help/en/api/index.html#/file/update.json)
+    # - this function is not (yet) implemented

--- a/res/FileMockup/Init/0All/.gitkeep
+++ b/res/FileMockup/Init/0All/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Init/0All/1Hallo/.gitkeep
+++ b/res/FileMockup/Init/0All/1Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Init/0All/2Hallo/.gitkeep
+++ b/res/FileMockup/Init/0All/2Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Init/0All/2Hallo/21Hallo/.gitkeep
+++ b/res/FileMockup/Init/0All/2Hallo/21Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Init/0All/2Hallo/21Hallo/211Hallo/.gitkeep
+++ b/res/FileMockup/Init/0All/2Hallo/21Hallo/211Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Init/0All/2Hallo/22Hallo/.gitkeep
+++ b/res/FileMockup/Init/0All/2Hallo/22Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Init/readme.md
+++ b/res/FileMockup/Init/readme.md
@@ -1,5 +1,0 @@
-* This '0All' folder won't be synced, it corresponds to the 'Alle Dateien'
-  Pseudo-Kategorie in the Kategorien sidebar
-
-* In the UI there is a Filter Checkbox where you can enable ***Ohne Dateien in
-  Unterkategorien***. Afterwards it feels much more like a real filesystem...

--- a/res/FileMockup/Nothing/0All/.gitkeep
+++ b/res/FileMockup/Nothing/0All/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev1/0All/.gitkeep
+++ b/res/FileMockup/Rev1/0All/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev1/0All/1Hallo/.gitkeep
+++ b/res/FileMockup/Rev1/0All/1Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev1/0All/1Hallo/1welt.txt
+++ b/res/FileMockup/Rev1/0All/1Hallo/1welt.txt
@@ -1,0 +1,1 @@
+hello world - 1welt

--- a/res/FileMockup/Rev1/0All/2Hallo/.gitkeep
+++ b/res/FileMockup/Rev1/0All/2Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev1/0All/2Hallo/21Hallo/.gitkeep
+++ b/res/FileMockup/Rev1/0All/2Hallo/21Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev1/0All/2Hallo/21Hallo/211Hallo/.gitkeep
+++ b/res/FileMockup/Rev1/0All/2Hallo/21Hallo/211Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev1/0All/2Hallo/21Hallo/211Hallo/211welt.txt
+++ b/res/FileMockup/Rev1/0All/2Hallo/21Hallo/211Hallo/211welt.txt
@@ -1,0 +1,1 @@
+hello world - 211welt

--- a/res/FileMockup/Rev1/0All/2Hallo/21Hallo/21welt1.txt
+++ b/res/FileMockup/Rev1/0All/2Hallo/21Hallo/21welt1.txt
@@ -1,0 +1,1 @@
+hello world - 21welt1

--- a/res/FileMockup/Rev1/0All/2Hallo/21Hallo/21welt3.txt
+++ b/res/FileMockup/Rev1/0All/2Hallo/21Hallo/21welt3.txt
@@ -1,0 +1,1 @@
+hello world - 21welt3

--- a/res/FileMockup/Rev1/0All/2Hallo/22Hallo/.gitkeep
+++ b/res/FileMockup/Rev1/0All/2Hallo/22Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev1/0All/2Hallo/2welt.txt
+++ b/res/FileMockup/Rev1/0All/2Hallo/2welt.txt
@@ -1,0 +1,1 @@
+hello world - 2welt

--- a/res/FileMockup/Rev1/0All/3Hallo/31Hallo/311Hallo/311welt.txt
+++ b/res/FileMockup/Rev1/0All/3Hallo/31Hallo/311Hallo/311welt.txt
@@ -1,0 +1,1 @@
+hello world - 311welt

--- a/res/FileMockup/Rev2/0All/.gitkeep
+++ b/res/FileMockup/Rev2/0All/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev2/0All/1Hallo/.gitkeep
+++ b/res/FileMockup/Rev2/0All/1Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev2/0All/1Hallo/1welt.txt
+++ b/res/FileMockup/Rev2/0All/1Hallo/1welt.txt
@@ -1,0 +1,3 @@
+hello world - 1welt
+
+File has been modified after 'Rev1/0All/1Hallo/1welt.txt' and should be updated on the server.

--- a/res/FileMockup/Rev2/0All/2Hallo/.gitkeep
+++ b/res/FileMockup/Rev2/0All/2Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev2/0All/2Hallo/21Hallo/.gitkeep
+++ b/res/FileMockup/Rev2/0All/2Hallo/21Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev2/0All/2Hallo/21Hallo/211Hallo/.gitkeep
+++ b/res/FileMockup/Rev2/0All/2Hallo/21Hallo/211Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev2/0All/2Hallo/21Hallo/211Hallo/211welt.txt
+++ b/res/FileMockup/Rev2/0All/2Hallo/21Hallo/211Hallo/211welt.txt
@@ -1,0 +1,1 @@
+hello world - 211welt

--- a/res/FileMockup/Rev2/0All/2Hallo/21Hallo/21welt1.txt
+++ b/res/FileMockup/Rev2/0All/2Hallo/21Hallo/21welt1.txt
@@ -1,0 +1,1 @@
+hello world - 21welt1

--- a/res/FileMockup/Rev2/0All/2Hallo/21Hallo/21welt3.txt
+++ b/res/FileMockup/Rev2/0All/2Hallo/21Hallo/21welt3.txt
@@ -1,0 +1,1 @@
+hello world - 21welt3

--- a/res/FileMockup/Rev2/0All/2Hallo/22Hallo/.gitkeep
+++ b/res/FileMockup/Rev2/0All/2Hallo/22Hallo/.gitkeep
@@ -1,0 +1,1 @@
+file needed to keep potentially empty folder

--- a/res/FileMockup/Rev2/0All/2Hallo/2welt.txt
+++ b/res/FileMockup/Rev2/0All/2Hallo/2welt.txt
@@ -1,0 +1,1 @@
+hello world - 2welt

--- a/res/FileMockup/Rev2/0All/3Hallo/31Hallo/311Hallo/311welt.txt
+++ b/res/FileMockup/Rev2/0All/3Hallo/31Hallo/311Hallo/311welt.txt
@@ -1,0 +1,1 @@
+hello world - 311welt

--- a/res/FileMockup/readme.md
+++ b/res/FileMockup/readme.md
@@ -1,0 +1,16 @@
+* These files and folders are used to test/implement the mirror functionality
+  - Init is the starting point, the files on the CC server must manually setup to this
+    state. If there are additional files on the server they will (should be)
+    downloaded to the local computer
+  - Rev<number> are subsequent states used for testing
+
+* The '0All' folder corresponds to the 'Alle Dateien' Pseudo-Kategorie in the
+  Kategorien sidebar. It is treated as the root and won't be synced
+
+* Further notes:
+  - as you can see from strings like 'Alle Dateien', there is a language dependency.
+    At the moment it has not been researched how this influences the mirroring. In any
+    case this is not good (FIXME)
+  - in the UI there is a Filter Checkbox where you can enable ***Ohne Dateien in
+    Unterkategorien***. Afterwards it feels much more like a real filesystem...
+

--- a/res/cctest_update.txt
+++ b/res/cctest_update.txt
@@ -1,12 +1,10 @@
 Manual testing required:
 
   - initially the file should be empty after the "==..." line
-  - manually upload the file to the root of the server (i.e. no category)
+  - (manually) upload the file to the server
   - then write something after the "==..." line
   - now save (and the local mtime is supposed to be after the server mtime of the file)
-  - call the 'file_update' function and check if 'cctest_update.txt' has been
-    updated on the server
-
+  - call the 'file_update' function and check 'cctest_update.txt' on the server
 
 ===================================================================
-Neu. Nun drittes Mal modifiziert.
+test

--- a/res/cctest_update.txt
+++ b/res/cctest_update.txt
@@ -1,0 +1,12 @@
+Manual testing required:
+
+  - initially the file should be empty after the "==..." line
+  - manually upload the file to the root of the server (i.e. no category)
+  - then write something after the "==..." line
+  - now save (and the local mtime is supposed to be after the server mtime of the file)
+  - call the 'file_update' function and check if 'cctest_update.txt' has been
+    updated on the server
+
+
+===================================================================
+Neu. Nun drittes Mal modifiziert.

--- a/res/cctest_update_orig/cctest_update.txt
+++ b/res/cctest_update_orig/cctest_update.txt
@@ -1,0 +1,11 @@
+Manual testing required:
+
+  - initially the file should be empty after the "==..." line
+  - manually upload the file to the root of the server (i.e. no category)
+  - then write something after the "==..." line
+  - now save (and the local mtime is supposed to be after the server mtime of the file)
+  - call the 'file_update' function and check if 'cctest_update.txt' has been
+    updated on the server
+
+
+===================================================================

--- a/tests/test_mirror_files.py
+++ b/tests/test_mirror_files.py
@@ -1,0 +1,30 @@
+import pytest
+from cashctrl_api import CashCtrlAPIClient
+
+def test_mirror_files():
+
+    if False:
+        # NOTE: this is my local test script. It must be decided how often and how far
+        #       we want to test. It might be a bit overwhelming if we fully delete and
+        #       recreate categories and files on each single commit...
+
+        # NOTE 2: until mtime / file update is finished it is likely easier to work with
+        #         simple functions instead of a class (my Python knowledge is limited alas)
+
+        with open('cctest_mirror.py', 'r') as file:
+            mirror_content = file.read()
+        exec(mirror_content)
+
+        cc = CashCtrlAPIClient()
+
+        # Rev1:
+        # - DELETED: 22welt.txt, 21welt2.txt
+        # - CREATED: 2Hallo/21Hallo/21welt3.txt, 3Hallo/31Hallo/311Hallo/311welt.txt
+        root = "~/dev/prj/le24/dev/cashctrl_api/res/FileMockup/Rev1/0All"
+
+        # Init:
+        # root = "~/dev/prj/le24/dev/cashctrl_api/res/FileMockup/Init/0All"
+
+        mirror_files(cc, root)
+
+    pass

--- a/tests/test_mirror_files.py
+++ b/tests/test_mirror_files.py
@@ -3,11 +3,11 @@ from cashctrl_api import CashCtrlAPIClient
 
 def test_mirror_files():
 
-    if True:
+    if False:
         # I'm not sure if we can/should run this code on every commit.
         # It will test run one time and then be disabled again (atm)
 
-        # In addition it doesn't work b/c the absolute path is wrong,
+        # In addition it doesn't work within github actions b/c the absolute path is wrong,
         # maybe because of [this](https://stackoverflow.com/questions/67586339/github-actions-get-absolute-path-to-working-directory)?
 
         cc = CashCtrlAPIClient()

--- a/tests/test_mirror_files.py
+++ b/tests/test_mirror_files.py
@@ -3,28 +3,19 @@ from cashctrl_api import CashCtrlAPIClient
 
 def test_mirror_files():
 
-    if False:
-        # NOTE: this is my local test script. It must be decided how often and how far
-        #       we want to test. It might be a bit overwhelming if we fully delete and
-        #       recreate categories and files on each single commit...
-
-        # NOTE 2: until mtime / file update is finished it is likely easier to work with
-        #         simple functions instead of a class (my Python knowledge is limited alas)
-
-        with open('cctest_mirror.py', 'r') as file:
-            mirror_content = file.read()
-        exec(mirror_content)
+    if True:
+        # I'm not sure if we can/should run this code on every commit.
+        # It will test run one time and then be disabled again (atm)
 
         cc = CashCtrlAPIClient()
 
-        # Rev1:
-        # - DELETED: 22welt.txt, 21welt2.txt
-        # - CREATED: 2Hallo/21Hallo/21welt3.txt, 3Hallo/31Hallo/311Hallo/311welt.txt
+        root = "~/dev/prj/le24/dev/cashctrl_api/res/FileMockup/Init/0All"
+        cc.mirror_files(root)
+
         root = "~/dev/prj/le24/dev/cashctrl_api/res/FileMockup/Rev1/0All"
+        cc.mirror_files(root)
 
-        # Init:
-        # root = "~/dev/prj/le24/dev/cashctrl_api/res/FileMockup/Init/0All"
-
-        mirror_files(cc, root)
-
-    pass
+        root = "~/dev/prj/le24/dev/cashctrl_api/res/FileMockup/Rev2/0All"
+        cc.mirror_files(root)
+    else:
+        pass

--- a/tests/test_mirror_files.py
+++ b/tests/test_mirror_files.py
@@ -7,6 +7,9 @@ def test_mirror_files():
         # I'm not sure if we can/should run this code on every commit.
         # It will test run one time and then be disabled again (atm)
 
+        # In addition it doesn't work b/c the absolute path is wrong,
+        # maybe because of [this](https://stackoverflow.com/questions/67586339/github-actions-get-absolute-path-to-working-directory)?
+
         cc = CashCtrlAPIClient()
 
         root = "~/dev/prj/le24/dev/cashctrl_api/res/FileMockup/Init/0All"


### PR DESCRIPTION
In the limited tests the functionality worked well, ...but:
- file update when local modified date is after the remote date is not handled (Reason: the basic file update functionality is _not_ yet implemented)
- it needs more testing (e.g. delete all remote files/categories, create initial state etc.)
- NOTE from the non-executed testcode: "It must be decided how often and how far we want to test. It might be a bit overwhelming if we fully delete and recreate categories and files on each single commit..."