### PR TITLE
Align remote categories with target category set

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Specialized methods manage more complex tasks:
 - `file_upload()` uploads a file and marks it for persistent storage.
 - `file_download()` downloads a file and saves it to the local file system.
 - `list_categories()` retrieves a category tree and flattens it to a pandas DataFrame.
-- `mirror_categories()` (TODO) aligns a category tree with a given set of nested categories.
+- `update_categories()` synchronizes a remote category tree with a given list of category paths,
+   adding new categories and optionally removing those that are no longer needed.
 - `mirror_files()` (TODO) mirrors a local set of nested categories with the category tree on the server.
     to the server, mapping local sub-folders to categories on the remote server.
 

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,56 @@
+import pandas as pd, pytest
+from cashctrl_api import CashCtrlAPIClient
+
+initial_categories = [
+    '/hello',
+    '/world',
+    '/how',
+    '/are',
+    '/you?'
+]
+
+further_categories = [
+    '/hello/world/how/are/you/?',
+    '/feeling/kind/of/warm',
+]
+
+def test_initial_category_creation():
+    """Test that categories are correctly created initially."""
+    cc = CashCtrlAPIClient()
+    cc.update_categories('file', categories=initial_categories)
+    remote_categories = cc.list_categories('file')
+    assert set(initial_categories) == set(remote_categories['path']), (
+        "Remote categories do not match initial categories")
+
+def test_category_addition():
+    """Test that new categories are added correctly (delete=False)."""
+    cc = CashCtrlAPIClient()
+    cc.update_categories('file', categories=further_categories, delete=False)
+    remote_categories = cc.list_categories('file')
+    assert set(further_categories).issubset(remote_categories['path']), (
+        "Not all initial categories appear in remote categories")
+
+def test_category_deletion():
+    """Test that categories are deleted when specified."""
+    cc = CashCtrlAPIClient()
+    cc.update_categories('file', categories=further_categories, delete=True)
+    remote_categories = cc.list_categories('file')
+    target = pd.Series(further_categories)
+    assert all([target.str.startswith(node).any() for node in remote_categories['path']]), (
+        "Remote categories do not match `further_categories'")
+
+def test_category_removal():
+    """Test that all categories are deleted when specified."""
+    cc = CashCtrlAPIClient()
+    cc.update_categories('file', categories=[], delete=True)
+    remote_categories = cc.list_categories('file')
+    assert len(remote_categories) == 0, "Some remote categories remain."
+
+def test_invalid_path():
+    """Test the system's response to invalid category paths."""
+    invalid_categories = ['not/a/valid/path', '']
+    cc = CashCtrlAPIClient()
+    with pytest.raises(Exception):
+        cc.update_categories('file', categories=invalid_categories[[0]])
+    with pytest.raises(Exception):
+        cc.update_categories('file', categories=invalid_categories[[1]])


### PR DESCRIPTION
- Add `update_categories()` to push a set of categories to the remote-
- Adapt `list_categories()` for coherence, drop system root in path name by default.
- Test