### PR TITLE
Enforce Data Frame Schema

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,14 +129,14 @@ For instance, if the API returns an empty list in above example, the DataFrame
 `df` will have no columns, resulting in an exception when trying to access
 the non-existent `df['account']` column.
 
-To mitigate runtime errors, we are developing the `enforce_column_types()`
+To mitigate runtime errors, we provide the `enforce_dtypes()`
 function to ensure DataFrames maintain expected columns and types,
 even if the data source returns unexpected results:
 
 ```python
 df = pd.DataFrame(cc_client.get('journal/list.json')['data'])
 columns = {'date': 'datetime64', 'amount': 'float', 'account': 'str'}
-df = enforce_column_types(df, required=columns)
+df = enforce_dtypes(df, required=columns)
 df.loc[df['account'] == '1020', 'amount'].sum()
 ```
 

--- a/cashctrl_api/__init__.py
+++ b/cashctrl_api/__init__.py
@@ -6,8 +6,10 @@ as well as to upload and download files.
 
 Modules:
 - client: Contains the CashCtrlClient class that encapsulates API interactions.
-- list_directory: Utility function for listing local directory contents.
+- list_directory: Provides a utility function listing local directory contents.
+- enforce_dtypes: Provides a method to enforce a DataFrame column schema.
 """
 
 from .client import CashCtrlClient
 from .list_directory import list_directory
+from .enforce_dtypes import enforce_dtypes

--- a/cashctrl_api/enforce_dtypes.py
+++ b/cashctrl_api/enforce_dtypes.py
@@ -1,0 +1,103 @@
+"""
+Module to enforce column schemas in pandas DataFrames.
+"""
+
+import pandas as pd
+import re
+from typing import Dict
+from zoneinfo import ZoneInfo
+
+def enforce_dtypes(
+    data: pd.DataFrame | None = None,
+    required: Dict[str, str] = {},
+    optional: Dict[str, str] = {},
+    keep_extra_columns: bool = False
+) -> pd.DataFrame:
+    """
+    Ensures that a DataFrame adheres to a specified column schema, enforcing
+    the presence and data types of specified columns.
+
+    If `data` is:
+    - None: Returns an empty DataFrame with required and optional columns.
+    - an empty DataFrame: Adds missing required and optional columns.
+    - a DataFrame with one or more columns: Adds missing optional columns, and
+      raises an exception if any required columns are missing.
+
+    Existing required and optional columns are converted to specified dtypes,
+    leading to an error if type conversion fails.
+
+    Parameters:
+        data: pd.DataFrame | None. The input DataFrame.
+        required: Dict[str, str]. Required columns and their dtypes.
+        optional: Dict[str, str]. Optional columns and their dtypes.
+        keep_extra_columns: bool. If True, columns not listed as required or
+                    optional are left unchanged in the resulting DataFrame.
+
+    Returns:
+        pd.DataFrame: A DataFrame with type-consistent columns.
+
+    Raises:
+        ValueError: If the input DataFrame is not empty and is missing any
+                    required columns.
+        TypeError: If the input data is not a pandas DataFrame or None, or
+                   if dtype conversion fails due to incompatible types.
+
+    Example:
+    --------
+    >>> required_columns = {'Column1': 'int64', 'Column2': 'float64'}
+    >>> optional_columns = {'Column3': 'object'}
+    >>> df = pd.DataFrame({'Column1': [1, 2], 'Column3': ['A', 'B']})
+    >>> enforce_dtypes(df, required_columns, optional_columns)
+       Column1  Column2 Column3
+    0        1      NaN       A
+    1        2      NaN       B
+    """
+    if not isinstance(data, pd.DataFrame) and data is not None:
+        raise TypeError("Data must be a pandas DataFrame or None.")
+
+    all_cols = {**required, **optional}
+
+    if data is None:
+        data = pd.DataFrame({col: pd.Series(dtype=dtype) for col, dtype in
+                             all_cols.items()})
+    else:
+        if data.empty:
+            for col, dtype in all_cols.items():
+                data[col] = pd.Series(dtype=dtype)
+
+        missing_cols = [col for col in required if col not in data.columns]
+        if missing_cols:
+            raise ValueError("Input DataFrame is missing required columns: "
+                             f"{missing_cols}")
+
+        for col, dtype in all_cols.items():
+            if col not in data:
+                data[col] = pd.Series(dtype=dtype)
+            else:
+                if dtype.startswith('datetime64'):
+                    if re.fullmatch('datetime64\\[ns\\]', dtype):
+                        timezone = None
+                    elif re.fullmatch('datetime64\\[ns, .+\\]', dtype):
+                        timezone_str = dtype.split(',')[1][:-1].strip()
+                        timezone = ZoneInfo(timezone_str)
+                    else:
+                        raise ValueError(f"Unknown datetime dtype: '{dtype}'.")
+                    # Convert to datetime and then localize timezone
+                    try:
+                        data[col] = pd.to_datetime(data[col])
+                    except pd._libs.tslibs.parsing.DateParseError as e:
+                        raise type(e)(f"Failed to convert '{col}' to {dtype}: {e}")
+                    if data[col].dt.tz is None:
+                        data[col] = data[col].dt.tz_localize(timezone)
+                    else:
+                        data[col] = data[col].dt.tz_convert(timezone)
+                else:
+                    try:
+                        data[col] = data[col].astype(dtype)
+                    except (TypeError, ValueError) as e:
+                        raise type(e)(f"Failed to convert '{col}' to {dtype}: {e}")
+
+        if not keep_extra_columns:
+            data = data[[col for col in data.columns if col in all_cols]]
+
+    return data

--- a/tests/test_enforce_dtypes.py
+++ b/tests/test_enforce_dtypes.py
@@ -1,0 +1,93 @@
+"""
+Unit tests for enforcing DataFrame column schema with enforce_dtypes().
+"""
+
+import pytest
+import pandas as pd
+from zoneinfo import ZoneInfo
+from cashctrl_api import enforce_dtypes
+
+def test_empty_input():
+    # Test input is None
+    result = enforce_dtypes(None)
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+    assert list(result.columns) == []
+
+def test_required_columns_added():
+    # Test adding required columns
+    required_columns = {'Column1': 'int64', 'Column2': 'float64'}
+    result = enforce_dtypes(None, required=required_columns)
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+    assert list(result.columns) == ['Column1', 'Column2']
+    assert result['Column1'].dtype == 'int64'
+    assert result['Column2'].dtype == 'float64'
+
+def test_optional_columns_added():
+    # Test adding optional columns
+    required_columns = {'Column1': 'int64'}
+    optional_columns = {'Column2': 'float64'}
+    df = pd.DataFrame({'Column1': [1]})
+    result = enforce_dtypes(data=df, required=required_columns, optional=optional_columns)
+    assert list(result.columns) == ['Column1', 'Column2']
+    assert result['Column2'].dtype == 'float64'
+
+def test_missing_required_columns():
+    # Test exception when missing required columns
+    df = pd.DataFrame({'Column3': ['data']})
+    required_columns = {'Column1': 'int64'}
+    with pytest.raises(ValueError):
+        enforce_dtypes(data=df, required=required_columns)
+
+def test_keep_extra_columns():
+    # Test dropping columns not in the required or optional lists
+    df = pd.DataFrame({'Column1': [1], 'Column3': ['extra']})
+    required_columns = {'Column1': 'int64'}
+    result = enforce_dtypes(data=df, required=required_columns, keep_extra_columns=False)
+    assert 'Column3' not in result.columns
+    assert list(result.columns) == ['Column1']
+    result = enforce_dtypes(data=df, required=required_columns, keep_extra_columns=True)
+    assert 'Column3' in result.columns
+    assert list(result.columns) == ['Column1', 'Column3']
+
+def test_dtype_conversion():
+    # Test dtype conversion where original vector has string elements interpretable as floats or integers
+    required_columns = {'Column1': 'int64', 'Column2': 'float64'}
+    optional_columns = {'Column3': 'object'}
+    df = pd.DataFrame({'Column1': ['1', '2', '3'], 'Column2': ['1.1', '2.2', '3.3']})
+    result = enforce_dtypes(data=df, required=required_columns, optional=optional_columns)
+    assert result['Column1'].dtype == 'int64'
+    assert result['Column2'].dtype == 'float64'
+
+def test_invalid_dtype_conversion():
+    # Test exception when dtype conversion is invalid
+    df = pd.DataFrame({'Column1': ['invalid'], 'Column2': ['data']})
+    required_columns = {'Column1': 'int64', 'Column2': 'float64'}
+    with pytest.raises(ValueError, match="^Failed to convert 'Column1' to int64:"):
+        enforce_dtypes(data=df, required=required_columns)
+
+def test_datetime_without_timezone():
+    # Test adding a datetime column without timezone
+    df = pd.DataFrame({'Column1': [1, 2], 'Date': ['2021-01-01', '2022-02-02']})
+    required_columns = {'Column1': 'int64', 'Date': 'datetime64[ns]'}
+    result = enforce_dtypes(data=df, required=required_columns)
+    assert pd.to_datetime('2021-01-01') in result['Date'].values
+    assert result['Date'].dtype == 'datetime64[ns]'
+
+def test_datetime_with_timezone():
+    # Test adding a datetime column with timezone using zoneinfo
+    df = pd.DataFrame({'Column1': [1], 'Date': ['2021-01-01T12:00:00']})
+    required_columns = {'Column1': 'int64', 'Date': 'datetime64[ns, US/Eastern]'}
+    result = enforce_dtypes(data=df, required=required_columns)
+    expected_date = pd.to_datetime('2021-01-01T12:00:00').tz_localize(ZoneInfo('US/Eastern'))
+    assert expected_date == result['Date'].dt.tz_convert('US/Eastern').item()
+    assert result['Date'].dtype == 'datetime64[ns, US/Eastern]'
+
+def test_datetime_conversion_fail():
+    # Test failure in converting invalid datetime format
+    df = pd.DataFrame({'Column1': [1], 'Date': ['not a date']})
+    required_columns = {'Column1': 'int64', 'Date': 'datetime64[ns]'}
+    with pytest.raises(pd._libs.tslibs.parsing.DateParseError,
+                       match="^Failed to convert 'Date' to datetime64\\[ns\\]:"):
+        enforce_dtypes(data=df, required=required_columns)


### PR DESCRIPTION
## Enforce DataFrame Schema

### Scope

- Add function `enforce_dtypes()` that returns a DataFrame with a guaranteed set of columns with known type.
- Modifies `list_files()` and `list_categories()` to return a type consistent DataFrame.

### Background

Converting the results of a GET request from '../list.json' to `pd.DataFrame` returns a reliable DataFrame only when the list is non-empty. If the list is empty, it results in a DataFrame with no columns, which can cause downstream errors. 

```python
cc_client = CashCtrlClient()
df = pd.DataFrame(cc_client.get('journal/list.json')['data'])
```

Refer to the [Type Consistency section](https://github.com/macxred/cashctrl_api/blob/main/CONTRIBUTING.md#type-consistency) in the CONTRIBUTING.md for more details.