### PR TITLE
Feat/create non existent account groups

### DIFF
--- a/cashctrl_api/client.py
+++ b/cashctrl_api/client.py
@@ -249,9 +249,9 @@ class CashCtrlClient:
                 self.post(f"{resource}/category/delete.json",
                           params={'ids': ','.join(delete_ids)})
 
-        if resource == 'account' and isinstance(target, list):
+        if resource == 'account' and not isinstance(target, dict):
             raise ValueError('Accounts target should be a dict of groups and associated account numbers')
-        elif resource != 'account' and not isinstance(target, list):
+        elif resource != 'account' and isinstance(target, dict):
             raise ValueError('Target categories should be a list for this resource')
 
         # TODO: In account case need to modify numbers if target differs from remote

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -91,7 +91,7 @@ def test_account_category_update():
     cc_client.update_categories('account', target=account_categories)
     remote_categories = cc_client.list_categories('account')
     assert set(account_categories).issubset(remote_categories['path']), (
-        "Not all categories appear were updated")
+        "Not all categories were updated")
 
     cc_client.update_categories('account', target=initial_paths, delete=True)
     updated = cc_client.list_categories('account')

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -18,6 +18,14 @@ more_categories = [
     '/feeling/kind/of/warm',
 ]
 
+account_categories = {
+    '/Anlagevermögen/hello': 1000,
+    '/Anlagevermögen/world/how/are/you/?': 1010,
+    '/Anlagevermögen/feeling/kind/of/warm': 1020,
+    '/Anlagevermögen/are': 1020,
+    '/Anlagevermögen/you?': 1020,
+}
+
 def test_initial_category_creation():
     """Test that categories are correctly created initially."""
     cc_client = CashCtrlClient()
@@ -61,3 +69,31 @@ def test_invalid_path():
         cc_client.update_categories('file', target=invalid_categories[[0]])
     with pytest.raises(Exception):
         cc_client.update_categories('file', target=invalid_categories[[1]])
+
+def test_update_account_categories_with_list():
+    """Test that should get error while updating account categories with target as a list type"""
+    cc_client = CashCtrlClient()
+    with pytest.raises(ValueError):
+        cc_client.update_categories('account', target=categories)
+
+def test_update_file_categories_with_dict():
+    """Test that should get error while updating file categories with target as a dict type"""
+    cc_client = CashCtrlClient()
+    with pytest.raises(ValueError):
+        cc_client.update_categories('file', target=account_categories)
+
+def test_account_category_addition():
+    """Test that new categories for accounts are added and deleted correctly"""
+    cc_client = CashCtrlClient()
+    initial_categories = cc_client.list_categories('account')
+    initial_paths = initial_categories['path'].tolist()
+    initial_paths_dict = { key: 1000 for key in initial_paths }
+
+    cc_client.update_categories('account', target=account_categories)
+    remote_categories = cc_client.list_categories('account')
+    assert set(account_categories).issubset(remote_categories['path']), (
+        "Not all initial categories appear in remote categories")
+
+    cc_client.update_categories('account', target=initial_paths_dict, delete=True)
+    remote_categories = cc_client.list_categories('account')
+    pd.testing.assert_frame_equal(initial_categories, remote_categories)


### PR DESCRIPTION
# Pull Request: Update Category Handling in CashCtrlClient

## Summary

This pull request introduces several updates and improvements to the `CashCtrlClient` class, particularly focusing on the handling of category updates. It includes new tests to validate these changes, ensuring robustness and correctness.

## Changes

### New Test Cases

1. **`test_update_account_categories_with_list`**
    - Ensures that updating account categories with a list type raises a `ValueError`.
2. **`test_update_file_categories_with_dict`**
    - Ensures that updating file categories with a dictionary type raises a `ValueError`.
3. **`test_account_category_update`**
    - Tests the full cycle of updating account categories and restoring the initial state.

### Code Updates

1. **Handling Parent ID for Account Categories**
    ```python
    elif resource == 'account':
        params['parentId'] = categories.get(parent_path, 1)
    if isinstance(target, dict) and target[category]:
        params['number'] = target[category]
    ```

2. **Updating Account Category Numbers**
    ```python
    if resource == 'account':
        dict_df = pd.DataFrame(list(target.items()), columns=['path', 'new_number'])
        merged = category_list.merge(dict_df, on='path', how='inner')
        merged.dropna(subset=['number', 'new_number'], inplace=True)
        update = merged[merged['number'] != merged['new_number']]
        for row in update.to_dict('records'):
            params = {
                'id': row['id'],
                'name': row['path'],
                'number': row['new_number'],
                'parentId': row['parentId']
            }
            self.post('account/category/update.json', params=params)
    ```

3. **Target Type Validation**
    ```python
    if resource == 'account' and not isinstance(target, dict):
        raise ValueError('Accounts target should be a dict of groups and associated account numbers')
    elif resource != 'account' and isinstance(target, dict):
        raise ValueError('Target categories should be a list for this resource')
    ```

4. **Update Categories Method Signature**
    ```python
    def update_categories(self, resource: str, target: List[str] | dict, delete: bool = False):
    ```

5. **Adding Number Column for Account Categories**
    ```python
    if resource == 'account':
        accounts = pd.DataFrame(self.get("account/list.json")['data'])
        accounts = accounts.groupby('categoryId', as_index=False).agg({'number': 'min'})
        df.drop(columns=['number'], inplace=True)
        df = pd.merge(df, accounts, how='left', left_on='id', right_on='categoryId')
    ```

6. **Enforcing Data Types**
    ```python
    df = enforce_dtypes(df, CATEGORY_COLUMNS, optional={'number': 'Int64'})
    ```

7. **Path Handling**
    ```python
    path = f"{parent_path}/{node['text'].replace('/', '\\/')}"
    ```

## Conclusion

@lasuk Please review the changes and provide feedback or approval for merging. 
There are not so many changes, so you can point to any part of code that you see we can improve