### PR TITLE
feat: create mappers functions for file paths

### DIFF
--- a/cashctrl_api/cashed_client.py
+++ b/cashctrl_api/cashed_client.py
@@ -388,10 +388,8 @@ class CachedCashCtrlClient(CashCtrlClient):
         super().upload_file(*args, **kwargs)
         self.invalidate_files_cache()
 
-    def update_categories(self, *args, **kwargs):
-        super().update_categories(*args, **kwargs)
-        resource = kwargs.get('resource', None)
-
+    def update_categories(self, resource: str, *args, **kwargs):
+        super().update_categories(resource, *args, **kwargs)
         if resource == 'file':
             self.invalidate_files_cache()
         elif resource == 'account':

--- a/cashctrl_api/cashed_client.py
+++ b/cashctrl_api/cashed_client.py
@@ -135,6 +135,46 @@ class CachedCashCtrlClient(CashCtrlClient):
             self._files_cache_time = datetime.now()
         return self._files_cache
 
+    def file_id_to_path(self, id: int, allow_missing: bool = False) -> str | None:
+        """
+        Retrieve the file path corresponding to a given id.
+
+        Returns:
+            str | none: The file path associated with the provided id
+                        or None is allow_missing is True and there is no such file path.
+        """
+        df = self.list_files()
+        result = df.loc[df['id'] == id, 'path']
+        if result.empty:
+            if  allow_missing:
+                return None
+            else:
+                raise ValueError(f"No path found for id: {id}")
+        elif len(result) > 1:
+            raise ValueError(f"Multiple paths found for id: {id}")
+        else:
+            return result.item()
+
+    def file_path_to_id(self, path: str, allow_missing: bool = False) -> int | None:
+        """
+        Retrieve the file id corresponding to a given file path.
+
+        Returns:
+            int | none: The id associated with the file path
+                        or None is allow_missing is True and there is no such file id.
+        """
+        df = self.list_files()
+        result = df.loc[df['path'] == path, 'id']
+        if result.empty:
+            if  allow_missing:
+                return None
+            else:
+                raise ValueError(f"No id found for path: {path}")
+        elif len(result) > 1:
+            raise ValueError(f"Multiple id found for path: {path}")
+        else:
+            return result.item()
+
     def account_from_id(self, id: int, allow_missing = False) -> int | None:
         """
         Retrieve the account number corresponding to a given id.

--- a/cashctrl_api/cashed_client.py
+++ b/cashctrl_api/cashed_client.py
@@ -380,32 +380,18 @@ class CachedCashCtrlClient(CashCtrlClient):
         else:
             return result.item()
 
-    def mirror_directory(self, directory: str | Path,
-                        delete_files: bool = False,
-                        delete_categories: bool = False):
-        super().mirror_directory(directory=directory,
-                                 delete_files=delete_files,
-                                 delete_categories=delete_categories)
+    def mirror_directory(self, *args, **kwargs):
+        super().mirror_directory(*args, **kwargs)
         self.invalidate_files_cache()
 
-    def upload_file(self,
-                    file: str | Path,
-                    id: int | str | None = None,
-                    name: str | None = None,
-                    category: int | str | None = None,
-                    mime_type: str | None = None) -> int:
-        super().upload_file(file=file,
-                            id=id,
-                            name=name,
-                            category=category,
-                            mime_type=mime_type)
+    def upload_file(self, *args, **kwargs) -> int:
+        super().upload_file(*args, **kwargs)
         self.invalidate_files_cache()
 
-    def update_categories(self, resource: str, target: Dict[str, int] | List[str],
-                          delete: bool = False):
-        super().update_categories(resource=resource,
-                                  target=target,
-                                  delete=delete)
+    def update_categories(self, *args, **kwargs):
+        super().update_categories(*args, **kwargs)
+        resource = kwargs.get('resource', None)
+
         if resource == 'file':
             self.invalidate_files_cache()
         elif resource == 'account':

--- a/cashctrl_api/cashed_client.py
+++ b/cashctrl_api/cashed_client.py
@@ -2,6 +2,7 @@
 Module to extend the CashCtrlClient class with caching capabilities.
 """
 
+import inspect
 from pathlib import Path
 import time
 from datetime import datetime, timedelta
@@ -382,23 +383,6 @@ class CachedCashCtrlClient(CashCtrlClient):
     def mirror_directory(self, directory: str | Path,
                         delete_files: bool = False,
                         delete_categories: bool = False):
-        """
-        Recursively mirrors a local directory on the CashCtrl server.
-        Invalidates files cache after mirroring.
-
-        Ensures that the remote file system reflects the state of the local
-        directory, and that local sub-folders are mapped to remote categories.
-        The method creates, updates, and optionally deletes files and
-        categories (folders) on the server to match the local structure.
-
-        Parameters:
-            directory (str | Path): Path of the local directory to mirror.
-            delete_files (bool, optional): If True, deletes remote files
-                without a corresponding local file. Also empties the recycle
-                bin to release references and allow for category deletion.
-            delete_categories (bool, optional): If True, deletes unused
-                categories (folders) on the server.
-        """
         super().mirror_directory(directory=directory,
                                  delete_files=delete_files,
                                  delete_categories=delete_categories)
@@ -410,23 +394,6 @@ class CachedCashCtrlClient(CashCtrlClient):
                     name: str | None = None,
                     category: int | str | None = None,
                     mime_type: str | None = None) -> int:
-        """
-        Uploads a file to the server, marks it for persistent storage and,
-        if a remote file `id` is provided, replaces an existing file.
-        Invalidates files cache after uploading.
-
-        Args:
-            path (str | Path): Path to the local file to upload.
-            id (int | str | None): id of remote file to replace with new file.
-            name (str | None): The filename on the remote server;
-                               defaults to the local file's base name.
-            category (int | str | None): id of category the file is stored in.
-            mime_type (str | None): The file's MIME type; guessed if not
-                                    provided.
-
-        Returns:
-            int: The Id of the newly created or replaced file.
-        """
         super().upload_file(file=file,
                             id=id,
                             name=name,
@@ -436,25 +403,6 @@ class CachedCashCtrlClient(CashCtrlClient):
 
     def update_categories(self, resource: str, target: Dict[str, int] | List[str],
                           delete: bool = False):
-        """
-        Updates the server's category tree for a specified resource,
-        synchronizing it with the provided category list.
-        Invalidates corresponding cache after.
-
-        Backslashes ('\\') in category names are converted to slashes ('/').
-        This allows slashes in category names while reserving the slash
-        character as separator for hierarchy levels in path notation.
-
-        Args:
-            resource (str): Resource type ('account', 'file', etc.).
-            target (Dict[str, int] | List[str]): Target category paths in Unix-like format.
-                                                 Type of [str, int] is suitable only for 'account' resource
-                                                 and represent key-value pairs of path and associated account number
-                                                 Type of List[str] is suitable for the rest of the resources and should
-                                                 contain just a list of paths in string format
-            delete (bool, optional): If True, deletes categories not present
-                                     in the provided list. Defaults to False.
-        """
         super().update_categories(resource=resource,
                                   target=target,
                                   delete=delete)
@@ -462,7 +410,6 @@ class CachedCashCtrlClient(CashCtrlClient):
             self.invalidate_files_cache()
         elif resource == 'account':
             self.invalidate_account_categories_cache()
-
 
     def invalidate_accounts_cache(self) -> None:
         """

--- a/cashctrl_api/cashed_client.py
+++ b/cashctrl_api/cashed_client.py
@@ -141,7 +141,7 @@ class CachedCashCtrlClient(CashCtrlClient):
 
         Returns:
             str | none: The file path associated with the provided id
-                        or None is allow_missing is True and there is no such file path.
+                        or None if allow_missing is True and there is no such file path.
         """
         df = self.list_files()
         result = df.loc[df['id'] == id, 'path']
@@ -161,7 +161,7 @@ class CachedCashCtrlClient(CashCtrlClient):
 
         Returns:
             int | none: The id associated with the file path
-                        or None is allow_missing is True and there is no such file id.
+                        or None if allow_missing is True and there is no such file id.
         """
         df = self.list_files()
         result = df.loc[df['path'] == path, 'id']

--- a/cashctrl_api/client.py
+++ b/cashctrl_api/client.py
@@ -262,7 +262,7 @@ class CashCtrlClient:
             if resource == 'account':
                 target_series = pd.Series(target.keys())
             else:
-                target_series = pd.Series(target).unique()
+                target_series = pd.Series(pd.Series(target).unique())
             to_delete = [node for node in category_list['path']
                          if not target_series.str.startswith(node).any()]
 

--- a/cashctrl_api/client.py
+++ b/cashctrl_api/client.py
@@ -262,7 +262,7 @@ class CashCtrlClient:
             if resource == 'account':
                 target_series = pd.Series(target.keys())
             else:
-                target_series = pd.Series(pd.Series(target).unique())
+                target_series = pd.Series(target).unique()
             to_delete = [node for node in category_list['path']
                          if not target_series.str.startswith(node).any()]
 

--- a/tests/test_cached_files.py
+++ b/tests/test_cached_files.py
@@ -40,13 +40,11 @@ def cc_client(mock_directory):
 
     yield cc_client
 
+    # Delete files added in the test
     files = cc_client.list_files()
-    # check is this needed
     to_delete = set(files['id']).difference(initial_files['id'])
     params = { 'ids': ','.join(str(i) for i in to_delete), 'force': True }
     cc_client.post("file/delete.json", params=params)
-    # Empty recycle bin to release references before category deletion
-    cc_client.post("file/empty_archive.json")
 
 @pytest.fixture(scope="module")
 def files(cc_client):

--- a/tests/test_cached_files.py
+++ b/tests/test_cached_files.py
@@ -57,6 +57,13 @@ def test_file_id_to_path(cc_client, files):
         'Cached file path doesn`t correspond actual'
     )
 
+def test_file_id_to_nested_path(cc_client, files):
+    path = "/nested/subdir/file4.txt"
+    id = files.loc[files['path'] == path, 'id'].item()
+    assert cc_client.file_id_to_path(id) == path, (
+        'Cached nested file path doesn`t correspond actual.'
+    )
+
 def test_file_id_to_path_invalid_id_raises_error(cc_client):
     with pytest.raises(ValueError, match='No path found for id'):
         cc_client.file_id_to_path(99999999)
@@ -65,6 +72,13 @@ def test_file_id_to_path_invalid_id_returns_none_when_allowed_missing(cc_client)
     assert cc_client.file_id_to_path(99999999, allow_missing=True) is None
 
 def test_file_path_to_id(cc_client, files):
+    path = "/nested/subdir/file4.txt"
+    id = files.loc[files['path'] == path, 'id'].item()
+    assert cc_client.file_path_to_id(path) == id, (
+        'Cached nested file id doesn`t correspond actual id'
+    )
+
+def test_nested_file_path_to_id(cc_client, files):
     assert cc_client.file_path_to_id(files['path'].iat[0]) == files['id'].iat[0], (
         'Cached file id doesn`t correspond actual id'
     )

--- a/tests/test_cached_files.py
+++ b/tests/test_cached_files.py
@@ -31,7 +31,6 @@ def cc_client(mock_directory):
     """Create a CachedCashCtrlClient, populate with files and folders."""
     cc_client = CachedCashCtrlClient()
     initial_files = cc_client.list_files()
-    # check is this needed
     cc_client.mirror_directory(mock_directory, delete_files=False)
 
     # We create a fresh instance with empty cache, because the cache is

--- a/tests/test_cached_files.py
+++ b/tests/test_cached_files.py
@@ -30,15 +30,25 @@ def mock_directory(tmp_path_for_module):
 def cc_client(mock_directory):
     """Create a CachedCashCtrlClient, populate with files and folders."""
     cc_client = CachedCashCtrlClient()
-    cc_client.mirror_directory(mock_directory, delete_files=True)
+    initial_files = cc_client.list_files()
+    # check is this needed
+    initial_categories = cc_client.list_categories('file')
+    cc_client.mirror_directory(mock_directory, delete_files=False)
 
     # We create a fresh instance with empty cache, because the cache is
     # populated when mirroring a directory
     cc_client = CachedCashCtrlClient()
 
-    # TODO: We should restore original files after the test is complete
+    yield cc_client
 
-    return cc_client
+    files = cc_client.list_files()
+    # check is this needed
+    to_delete = set(files['id']).difference(initial_files['id'])
+    params = { 'ids': ','.join(str(i) for i in to_delete), 'force': True }
+    cc_client.post("file/delete.json", params=params)
+    # Empty recycle bin to release references before category deletion
+    cc_client.post("file/empty_archive.json")
+    cc_client.update_categories('file', target=initial_categories['path'], delete=True)
 
 @pytest.fixture(scope="module")
 def files(cc_client):

--- a/tests/test_cached_files.py
+++ b/tests/test_cached_files.py
@@ -16,12 +16,56 @@ def files():
     cc_client = CachedCashCtrlClient()
     return CashCtrlClient.list_files(cc_client)
 
+@pytest.fixture
+def mock_directory(tmp_path):
+    """Create a temporary directory, populate with files and folders."""
+    (tmp_path / 'file1.txt').write_text("This is a text file.")
+    (tmp_path / 'file2.log').write_text("Log content here.")
+    subdir = tmp_path / 'subdir'
+    subdir.mkdir(exist_ok=True)
+    (subdir / 'file3.txt').write_text("A Text file in a subdirectory.")
+    nested_subdir = tmp_path / 'nested' / 'subdir'
+    nested_subdir.mkdir(parents=True, exist_ok=True)
+    (nested_subdir / 'file4.txt').write_text("File in the nested directory.")
+    (nested_subdir / 'file5.log').write_text("Another nested directory file.")
+    return tmp_path
+
 def test_files_cache_is_none_on_init(cc_client):
     assert cc_client._files_cache == None
     assert cc_client._files_cache_time == None
 
 def test_cached_files_same_to_actual(cc_client, files):
     pd.testing.assert_frame_equal(cc_client.list_files(), files)
+
+def test_file_id_to_path(cc_client, mock_directory):
+    cc_client.mirror_directory(mock_directory, delete_files=True)
+    cc_client.invalidate_files_cache()
+    files = CashCtrlClient.list_files(cc_client)
+    assert cc_client.file_id_to_path(files['id'].iat[0]) == files['path'].iat[0], (
+        'Cached file doesn`t correspond actual'
+    )
+
+def test_file_id_to_path_invalid_id_raises_error(cc_client):
+    with pytest.raises(ValueError, match='No path found for id'):
+        cc_client.file_id_to_path(99999999)
+
+def test_file_id_to_path_invalid_id_returns_none_when_allowed_missing(cc_client):
+    cc_client.file_id_to_path(99999999, allow_missing=True) == None
+
+def test_file_path_to_id(cc_client, mock_directory):
+    cc_client.mirror_directory(mock_directory, delete_files=True)
+    cc_client.invalidate_files_cache()
+    files = CashCtrlClient.list_files(cc_client)
+    assert cc_client.file_path_to_id(files['path'].iat[0]) == files['id'].iat[0], (
+        'Cached file id doesn`t correspond actual id'
+    )
+
+def test_file_path_to_id_with_invalid_path_raises_error(cc_client):
+    with pytest.raises(ValueError, match='No id found for path'):
+        cc_client.file_path_to_id(99999999)
+
+def test_file_path_to_id_with_invalid_returns_none_when_allowed_missing(cc_client):
+    cc_client.file_path_to_id(99999999, allow_missing=True) == None
 
 def test_files_cache_timeout(cc_client):
     cc_client = CachedCashCtrlClient(cache_timeout=1)

--- a/tests/test_cached_files.py
+++ b/tests/test_cached_files.py
@@ -32,7 +32,6 @@ def cc_client(mock_directory):
     cc_client = CachedCashCtrlClient()
     initial_files = cc_client.list_files()
     # check is this needed
-    initial_categories = cc_client.list_categories('file')
     cc_client.mirror_directory(mock_directory, delete_files=False)
 
     # We create a fresh instance with empty cache, because the cache is
@@ -48,7 +47,6 @@ def cc_client(mock_directory):
     cc_client.post("file/delete.json", params=params)
     # Empty recycle bin to release references before category deletion
     cc_client.post("file/empty_archive.json")
-    cc_client.update_categories('file', target=initial_categories['path'], delete=True)
 
 @pytest.fixture(scope="module")
 def files(cc_client):

--- a/tests/test_cached_files.py
+++ b/tests/test_cached_files.py
@@ -31,8 +31,8 @@ def mock_directory(tmp_path):
     return tmp_path
 
 def test_files_cache_is_none_on_init(cc_client):
-    assert cc_client._files_cache == None
-    assert cc_client._files_cache_time == None
+    assert cc_client._files_cache is None
+    assert cc_client._files_cache_time is None
 
 def test_cached_files_same_to_actual(cc_client, files):
     pd.testing.assert_frame_equal(cc_client.list_files(), files)
@@ -42,7 +42,7 @@ def test_file_id_to_path(cc_client, mock_directory):
     cc_client.invalidate_files_cache()
     files = CashCtrlClient.list_files(cc_client)
     assert cc_client.file_id_to_path(files['id'].iat[0]) == files['path'].iat[0], (
-        'Cached file doesn`t correspond actual'
+        'Cached file path doesn`t correspond actual'
     )
 
 def test_file_id_to_path_invalid_id_raises_error(cc_client):
@@ -50,7 +50,7 @@ def test_file_id_to_path_invalid_id_raises_error(cc_client):
         cc_client.file_id_to_path(99999999)
 
 def test_file_id_to_path_invalid_id_returns_none_when_allowed_missing(cc_client):
-    cc_client.file_id_to_path(99999999, allow_missing=True) == None
+    assert cc_client.file_id_to_path(99999999, allow_missing=True) is None
 
 def test_file_path_to_id(cc_client, mock_directory):
     cc_client.mirror_directory(mock_directory, delete_files=True)
@@ -65,7 +65,7 @@ def test_file_path_to_id_with_invalid_path_raises_error(cc_client):
         cc_client.file_path_to_id(99999999)
 
 def test_file_path_to_id_with_invalid_returns_none_when_allowed_missing(cc_client):
-    cc_client.file_path_to_id(99999999, allow_missing=True) == None
+    assert cc_client.file_path_to_id(99999999, allow_missing=True) is None
 
 def test_files_cache_timeout(cc_client):
     cc_client = CachedCashCtrlClient(cache_timeout=1)


### PR DESCRIPTION
This pull request covers 2 functions:

1. `file_id_to_path()`
2. `file_path_to_id()`

This functions will help to easily find id or path in the cached files.

@lasuk Please review the changes and provide feedback or approval for merging.