### PR TITLE
feat: implement class navigation in large class definitions

### DIFF
--- a/cashctrl_api/cashed_client.py
+++ b/cashctrl_api/cashed_client.py
@@ -15,6 +15,9 @@ class CachedCashCtrlClient(CashCtrlClient):
     invalidated.
     """
 
+    # ----------------------------------------------------------------------
+    # Constructors
+
     def __init__(self, *args, cache_timeout: int = 300, **kwargs):
         """Initializes the cached client with an optional cache timeout.
 
@@ -39,96 +42,43 @@ class CachedCashCtrlClient(CashCtrlClient):
         self._files_cache: Optional[pd.DataFrame] = None
         self._files_cache_time: Optional[datetime] = None
 
-    @property
-    def cache_timeout(self) -> int:
-        """Gets the current cache timeout.
+    # ----------------------------------------------------------------------
+    # Helper Methods
 
-        Returns:
-            int: The cache timeout in seconds.
-        """
-        return self._cache_timeout
-
-    @cache_timeout.setter
-    def cache_timeout(self, timeout: int) -> None:
-        """Sets a new cache timeout.
+    def _is_expired(self, cache_time: Optional[datetime]) -> bool:
+        """Checks if the cache has expired based on the cache timeout.
 
         Args:
-            timeout (int): The new cache timeout in seconds.
-        """
-        self._cache_timeout = timeout
-
-    def list_accounts(self) -> pd.DataFrame:
-        """Lists remote accounts with their attributes, and caches the result.
+            cache_time (datetime | None): The timestamp when the cache was last updated.
 
         Returns:
-            pd.DataFrame: A DataFrame with CashCtrlClient.ACCOUNT_COLUMNS schema.
+            bool: True if the cache is expired or cache_time is None, False otherwise.
         """
-        if self._accounts_cache is None or self._is_expired(self._accounts_cache_time):
-            self._accounts_cache = super().list_accounts()
-            self._accounts_cache_time = datetime.now()
-        return self._accounts_cache
+        if cache_time is None:
+            return True
+        return (datetime.now() - cache_time) > timedelta(seconds=self._cache_timeout)
 
-    def list_journal_entries(self) -> pd.DataFrame:
-        """Lists remote journal entries with their attributes, and caches the result.
+    # ----------------------------------------------------------------------
+    # API Requests
 
-        Returns:
-            pd.DataFrame: A DataFrame with CashCtrlClient.JOURNAL_ENTRIES schema.
-        """
-        if self._journal_cache is None or self._is_expired(self._journal_cache_time):
-            self._journal_cache = super().list_journal_entries()
-            self._journal_cache_time = datetime.now()
-        return self._journal_cache
+    def get(self, endpoint: str, data: dict = None, params: dict = None) -> dict:
+        """Send GET request. See json_request for args and return value."""
+        return self.json_request("GET", endpoint, data=data, params=params)
 
-    def list_currencies(self) -> pd.DataFrame:
-        """Lists remote currencies with their attributes, and caches the result.
+    def post(self, endpoint: str, data: dict = None, params: dict = None) -> dict:
+        """Send POST request. See json_request for args and return value."""
+        return self.json_request("POST", endpoint, data=data, params=params)
 
-        Returns:
-            pd.DataFrame: A DataFrame with currencies.
-        """
-        if self._currencies_cache is None or self._is_expired(self._currencies_cache_time):
-            self._currencies_cache = pd.DataFrame(self.get("currency/list.json")["data"])
-            self._currencies_cache_time = datetime.now()
-        return self._currencies_cache
+    def put(self, endpoint: str, data: dict = None, params: dict = None) -> dict:
+        """Send PUT request. See json_request for args and return value."""
+        return self.json_request("PUT", endpoint, data=data, params=params)
 
-    def list_account_categories(self) -> pd.DataFrame:
-        """Lists remote account categories with their attributes, and caches the result.
+    def delete(self, endpoint: str, data: dict = None, params: dict = None) -> dict:
+        """Send DELETE request. See json_request for args and return value."""
+        return self.json_request("DELETE", endpoint, data=data, params=params)
 
-        Returns:
-            pd.DataFrame: A DataFrame with CashCtrlClient.CATEGORY_COLUMNS
-                          | {'number': 'Int64'} schema.
-        """
-        if (
-            self._account_categories_cache is None
-            or self._is_expired(self._account_categories_cache_time)
-        ):
-            self._account_categories_cache = self.list_categories(
-                "account", include_system=True
-            )
-            self._account_categories_cache_time = datetime.now()
-        return self._account_categories_cache
-
-    def list_tax_rates(self) -> pd.DataFrame:
-        """Lists remote tax rates with their attributes, and caches the result.
-
-        Returns:
-            pd.DataFrame: A DataFrame with CashCtrlClient.TAX_COLUMNS schema.
-        """
-        if self._tax_rates_cache is None or self._is_expired(self._tax_rates_cache_time):
-            self._tax_rates_cache = super().list_tax_rates()
-            self._tax_rates_cache_time = datetime.now()
-        return self._tax_rates_cache
-
-    def list_files(self) -> pd.DataFrame:
-        """List remote files with their attributes. Add the files' hierarchical
-        position in the category tree in Unix-like filepath format.
-
-        Returns:
-            pd.DataFrame: A DataFrame with CashCtrlClient.FILE_COLUMNS schema.
-        """
-        if self._files_cache is None or self._is_expired(self._files_cache_time):
-            self._files_cache = super().list_files()
-            self._files_cache_time = datetime.now()
-        return self._files_cache
+    # ----------------------------------------------------------------------
+    # File Operations
 
     def file_id_to_path(self, id: int, allow_missing: bool = False) -> Optional[str]:
         """Retrieve the file path corresponding to a given id.
@@ -167,6 +117,105 @@ class CachedCashCtrlClient(CashCtrlClient):
             raise ValueError(f"Multiple id found for path: {path}")
         else:
             return result.item()
+
+    def mirror_directory(self, *args, **kwargs):
+        super().mirror_directory(*args, **kwargs)
+        self.invalidate_files_cache()
+
+    def upload_file(self, *args, **kwargs) -> int:
+        super().upload_file(*args, **kwargs)
+        self.invalidate_files_cache()
+
+    def update_categories(self, resource: str, *args, **kwargs):
+        super().update_categories(resource, *args, **kwargs)
+        if resource == "file":
+            self.invalidate_files_cache()
+        elif resource == "account":
+            self.invalidate_account_categories_cache()
+
+    # ----------------------------------------------------------------------
+    # Tax Rates
+
+    def list_tax_rates(self) -> pd.DataFrame:
+        """Lists remote tax rates with their attributes, and caches the result.
+
+        Returns:
+            pd.DataFrame: A DataFrame with CashCtrlClient.TAX_COLUMNS schema.
+        """
+        if self._tax_rates_cache is None or self._is_expired(self._tax_rates_cache_time):
+            self._tax_rates_cache = super().list_tax_rates()
+            self._tax_rates_cache_time = datetime.now()
+        return self._tax_rates_cache
+
+    def tax_code_from_id(self, id: int, allow_missing: bool = False) -> Optional[str]:
+        """Retrieve the tax code name corresponding to a given id.
+
+        Args:
+            id (int): The id of the tax code.
+            allow_missing (boolean): If True, return None if the tax id does not exist.
+                                     Otherwise raise a ValueError.
+
+        Returns:
+            str | None: The tax code name associated with the provided id.
+                        or None if allow_missing is True and there is no such tax code.
+
+        Raises:
+            ValueError: If the tax id does not exist and allow_missing=False,
+                        or if the id is duplicated.
+        """
+        df = self.list_tax_rates()
+        result = df.loc[df["id"] == id, "name"]
+        if result.empty:
+            if allow_missing:
+                return None
+            else:
+                raise ValueError(f"No tax code found for id: {id}")
+        elif len(result) > 1:
+            raise ValueError(f"Multiple tax codes found for id: {id}")
+        else:
+            return result.item()
+
+    def tax_code_to_id(self, name: str, allow_missing: bool = False) -> Optional[int]:
+        """Retrieve the id corresponding to a given tax code name.
+
+        Args:
+            name (str): The tax code name.
+            allow_missing (boolean): If True, return None if the tax code does not exist.
+                                     Otherwise raise a ValueError.
+
+        Returns:
+            int | None: The id associated with the provided tax code name.
+                        or None if allow_missing is True and there is no such tax code.
+
+        Raises:
+            ValueError: If the tax code does not exist and allow_missing=False,
+                        or if the tax code is duplicated.
+        """
+        df = self.list_tax_rates()
+        result = df.loc[df["name"] == name, "id"]
+        if result.empty:
+            if allow_missing:
+                return None
+            else:
+                raise ValueError(f"No id found for tax code {name}")
+        elif len(result) > 1:
+            raise ValueError(f"Multiple ids found for tax code {name}")
+        else:
+            return result.item()
+
+    # ----------------------------------------------------------------------
+    # Accounts
+
+    def list_accounts(self) -> pd.DataFrame:
+        """Lists remote accounts with their attributes, and caches the result.
+
+        Returns:
+            pd.DataFrame: A DataFrame with CashCtrlClient.ACCOUNT_COLUMNS schema.
+        """
+        if self._accounts_cache is None or self._is_expired(self._accounts_cache_time):
+            self._accounts_cache = super().list_accounts()
+            self._accounts_cache_time = datetime.now()
+        return self._accounts_cache
 
     def account_from_id(self, id: int, allow_missing: bool = False) -> Optional[int]:
         """Retrieve the account number corresponding to a given id.
@@ -252,47 +301,25 @@ class CachedCashCtrlClient(CashCtrlClient):
         else:
             return result.item()
 
-    def currency_from_id(self, id: int) -> str:
-        """Retrieve the currency corresponding to a given id.
+    # ----------------------------------------------------------------------
+    # Categories
 
-        Args:
-            id (int): The id of the currency.
-
-        Returns:
-            str: The currency name associated with the provided id.
-
-        Raises:
-            ValueError: If the currency id does not exist or is duplicated.
-        """
-        df = self.list_currencies()
-        result = df.loc[df["id"] == id, "text"]
-        if result.empty:
-            raise ValueError(f"No currency found for id: {id}")
-        elif len(result) > 1:
-            raise ValueError(f"Multiple currencies found for id: {id}")
-        else:
-            return result.item()
-
-    def currency_to_id(self, name: str) -> int:
-        """Retrieve the id corresponding to a given currency name.
-
-        Args:
-            text (srt): The currency name.
+    def list_account_categories(self) -> pd.DataFrame:
+        """Lists remote account categories with their attributes, and caches the result.
 
         Returns:
-            int: The id associated with the provided currency name.
-
-        Raises:
-            ValueError: If the currency does not exist or is duplicated.
+            pd.DataFrame: A DataFrame with CashCtrlClient.CATEGORY_COLUMNS
+                          | {'number': 'Int64'} schema.
         """
-        df = self.list_currencies()
-        result = df.loc[df["text"] == name, "id"]
-        if result.empty:
-            raise ValueError(f"No id found for currency: {name}")
-        elif len(result) > 1:
-            raise ValueError(f"Multiple ids found for currency: {name}")
-        else:
-            return result.item()
+        if (
+            self._account_categories_cache is None
+            or self._is_expired(self._account_categories_cache_time)
+        ):
+            self._account_categories_cache = self.list_categories(
+                "account", include_system=True
+            )
+            self._account_categories_cache_time = datetime.now()
+        return self._account_categories_cache
 
     def account_category_to_id(self, path: str) -> int:
         """Retrieve the id corresponding to a given category path.
@@ -336,76 +363,22 @@ class CachedCashCtrlClient(CashCtrlClient):
         else:
             return result.item()
 
-    def tax_code_from_id(self, id: int, allow_missing: bool = False) -> Optional[str]:
-        """Retrieve the tax code name corresponding to a given id.
+    # ----------------------------------------------------------------------
+    # Ledger
 
-        Args:
-            id (int): The id of the tax code.
-            allow_missing (boolean): If True, return None if the tax id does not exist.
-                                     Otherwise raise a ValueError.
+    def list_journal_entries(self) -> pd.DataFrame:
+        """Lists remote journal entries with their attributes, and caches the result.
 
         Returns:
-            str | None: The tax code name associated with the provided id.
-                        or None if allow_missing is True and there is no such tax code.
-
-        Raises:
-            ValueError: If the tax id does not exist and allow_missing=False,
-                        or if the id is duplicated.
+            pd.DataFrame: A DataFrame with CashCtrlClient.JOURNAL_ENTRIES schema.
         """
-        df = self.list_tax_rates()
-        result = df.loc[df["id"] == id, "name"]
-        if result.empty:
-            if allow_missing:
-                return None
-            else:
-                raise ValueError(f"No tax code found for id: {id}")
-        elif len(result) > 1:
-            raise ValueError(f"Multiple tax codes found for id: {id}")
-        else:
-            return result.item()
+        if self._journal_cache is None or self._is_expired(self._journal_cache_time):
+            self._journal_cache = super().list_journal_entries()
+            self._journal_cache_time = datetime.now()
+        return self._journal_cache
 
-    def tax_code_to_id(self, name: str, allow_missing: bool = False) -> Optional[int]:
-        """Retrieve the id corresponding to a given tax code name.
-
-        Args:
-            name (str): The tax code name.
-            allow_missing (boolean): If True, return None if the tax code does not exist.
-                                     Otherwise raise a ValueError.
-
-        Returns:
-            int | None: The id associated with the provided tax code name.
-                        or None if allow_missing is True and there is no such tax code.
-
-        Raises:
-            ValueError: If the tax code does not exist and allow_missing=False,
-                        or if the tax code is duplicated.
-        """
-        df = self.list_tax_rates()
-        result = df.loc[df["name"] == name, "id"]
-        if result.empty:
-            if allow_missing:
-                return None
-            else:
-                raise ValueError(f"No id found for tax code {name}")
-        elif len(result) > 1:
-            raise ValueError(f"Multiple ids found for tax code {name}")
-        else:
-            return result.item()
-
-    def mirror_directory(self, *args, **kwargs):
-        super().mirror_directory(*args, **kwargs)
-        self.invalidate_files_cache()
-
-    def upload_file(self, *args, **kwargs) -> int:
-        super().upload_file(*args, **kwargs)
-        self.invalidate_files_cache()
-
-    def update_categories(self, resource: str, *args, **kwargs):
-        super().update_categories(resource, *args, **kwargs)
-        if resource == "file":
-            self.invalidate_files_cache()
-        elif resource == "account":
-            self.invalidate_account_categories_cache()
+    # ----------------------------------------------------------------------
+    # Cache Invalidation
 
     def invalidate_accounts_cache(self) -> None:
         """Invalidates the cached accounts data."""
@@ -436,16 +409,3 @@ class CachedCashCtrlClient(CashCtrlClient):
         """Invalidates the cached files data."""
         self._files_cache = None
         self._files_cache_time = None
-
-    def _is_expired(self, cache_time: Optional[datetime]) -> bool:
-        """Checks if the cache has expired based on the cache timeout.
-
-        Args:
-            cache_time (datetime | None): The timestamp when the cache was last updated.
-
-        Returns:
-            bool: True if the cache is expired or cache_time is None, False otherwise.
-        """
-        if cache_time is None:
-            return True
-        return (datetime.now() - cache_time) > timedelta(seconds=self._cache_timeout)

--- a/cashctrl_api/cashed_client.py
+++ b/cashctrl_api/cashed_client.py
@@ -42,6 +42,9 @@ class CachedCashCtrlClient(CashCtrlClient):
         self._files_cache: Optional[pd.DataFrame] = None
         self._files_cache_time: Optional[datetime] = None
 
+    # ----------------------------------------------------------------------
+    # Cache Invalidation
+
     @property
     def cache_timeout(self) -> int:
         """Gets the current cache timeout.
@@ -59,9 +62,6 @@ class CachedCashCtrlClient(CashCtrlClient):
             timeout (int): The new cache timeout in seconds.
         """
         self._cache_timeout = timeout
-
-    # ----------------------------------------------------------------------
-    # Helper Methods
 
     def _is_expired(self, cache_time: Optional[datetime]) -> bool:
         """Checks if the cache has expired based on the cache timeout.

--- a/cashctrl_api/cashed_client.py
+++ b/cashctrl_api/cashed_client.py
@@ -107,25 +107,6 @@ class CachedCashCtrlClient(CashCtrlClient):
         self._files_cache_time = None
 
     # ----------------------------------------------------------------------
-    # API Requests
-
-    def get(self, endpoint: str, data: dict = None, params: dict = None) -> dict:
-        """Send GET request. See json_request for args and return value."""
-        return self.json_request("GET", endpoint, data=data, params=params)
-
-    def post(self, endpoint: str, data: dict = None, params: dict = None) -> dict:
-        """Send POST request. See json_request for args and return value."""
-        return self.json_request("POST", endpoint, data=data, params=params)
-
-    def put(self, endpoint: str, data: dict = None, params: dict = None) -> dict:
-        """Send PUT request. See json_request for args and return value."""
-        return self.json_request("PUT", endpoint, data=data, params=params)
-
-    def delete(self, endpoint: str, data: dict = None, params: dict = None) -> dict:
-        """Send DELETE request. See json_request for args and return value."""
-        return self.json_request("DELETE", endpoint, data=data, params=params)
-
-    # ----------------------------------------------------------------------
     # Categories
 
     def list_account_categories(self) -> pd.DataFrame:

--- a/cashctrl_api/client.py
+++ b/cashctrl_api/client.py
@@ -23,7 +23,7 @@ class CashCtrlClient:
     """
 
     # ----------------------------------------------------------------------
-    # Constructors
+    # Constructor
 
     def __init__(self, organisation: str = None, api_key: str = None):
         """Initializes the API client with the organization's domain and API key.
@@ -143,218 +143,6 @@ class CashCtrlClient:
     def delete(self, endpoint: str, data: dict = None, params: dict = None) -> dict:
         """Send DELETE request. See json_request for args and return value."""
         return self.json_request("DELETE", endpoint, data=data, params=params)
-
-    # ----------------------------------------------------------------------
-    # File Operations
-
-    def upload_file(
-        self,
-        file: str | Path,
-        id: int | str | None = None,
-        name: str | None = None,
-        category: int | str | None = None,
-        mime_type: str | None = None,
-    ) -> int:
-        """Uploads a file to the server, marks it for persistent storage and,
-        if a remote file `id` is provided, replaces an existing file.
-
-        Args:
-            file (str | Path): Path to the local file to upload.
-            id (int | str | None, optional): ID of remote file to replace with new file.
-            name (str | None, optional): The filename on the remote server;
-                                         defaults to the local file's base name.
-            category (int | str | None, optional): ID of category the file is stored in.
-            mime_type (str | None, optional): The file's MIME type; guessed if not provided.
-
-        Returns:
-            int: The ID of the newly created or replaced file.
-
-        Raises:
-            FileNotFoundError: If the specified file does not exist.
-            ValueError: If the response does not contain exactly one file ID.
-            HTTPError: If the file upload fails.
-        """
-        path = Path(file).expanduser()
-        if not path.is_file():
-            raise FileNotFoundError(f"File not found: '{file}'")
-        files = [
-            {
-                "mimeType": (mime_type if mime_type is not None
-                             else guess_type(path)[0] or "text/plain"),
-                "name": name if name is not None else path.name,
-                "categoryId": category,
-            }
-        ]
-        response = self.post("file/prepare.json", params={"files": files})
-        if len(response["data"]) != 1:
-            raise ValueError("Expected response['data'] with length 1.")
-        new_file_id = response["data"][0]["fileId"]
-        write_url = response["data"][0]["writeUrl"]
-
-        with open(path, "rb") as file:
-            headers = {"Content-Type": "application/octet-stream"}
-            response = put(write_url, file, headers=headers, timeout=60)
-        if response.status_code != 200:
-            raise HTTPError(f"File upload failed: {response.reason}.")
-
-        if id is None:
-            self.post("file/persist.json", params={"ids": new_file_id})
-            return new_file_id
-        else:
-            params = {
-                "id": id,
-                "name": name if name is not None else path.name,
-                "replaceWith": new_file_id,
-                "categoryId": category,
-            }
-            self.post("file/update.json", params=params)
-            return int(id)
-
-    def download_file(self, id: int | str, path: str | Path):
-        """Downloads a file identified by a remote ID and saves it locally.
-
-        Args:
-            id (int | str): The remote file ID to download.
-            path (str | Path): Local path to save the downloaded file.
-        """
-        response = self.request("GET", endpoint="file/get", params={"id": id})
-        with open(Path(path).expanduser(), "wb") as file:
-            file.write(response.content)
-
-    def list_files(self) -> pd.DataFrame:
-        """List remote files with their attributes. Add the files' hierarchical
-        position in the category tree in Unix-like filepath format.
-
-        Returns:
-            pd.DataFrame: A DataFrame with CashCtrlClient.FILE_COLUMNS schema.
-        """
-        files = pd.DataFrame(self.get("file/list.json")["data"])
-        columns_except_path = {
-            key: value for key, value in FILE_COLUMNS.items() if key != "path"
-        }
-        df = enforce_dtypes(files, columns_except_path)
-        if len(df) > 0:
-            categories = self.list_categories("file")[["path", "id"]]
-            categories = categories.rename(columns={"id": "categoryId"})
-            df = df.merge(categories, on="categoryId", how="left")
-            df["path"] = df["path"].fillna("") + "/" + df["name"]
-        df = enforce_dtypes(df, FILE_COLUMNS)
-        return df.sort_values("path")
-
-    def mirror_directory(
-        self,
-        directory: str | Path,
-        delete_files: bool = False,
-        delete_categories: bool = False,
-    ):
-        """Recursively mirrors a local directory on the CashCtrl server.
-
-        Ensures that the remote file system reflects the state of the local
-        directory, and that local sub-folders are mapped to remote categories.
-        The method creates, updates, and optionally deletes files and
-        categories (folders) on the server to match the local structure.
-
-        Args:
-            directory (str | Path): Path of the local directory to mirror.
-            delete_files (bool, optional): If True, deletes remote files without
-                                           a corresponding local file. Also empties
-                                           the recycle bin to release references
-                                           and allow for category deletion.
-            delete_categories (bool, optional): If True, deletes unused categories
-                                                (folders) on the server.
-        """
-        local_files = list_directory(directory, recursive=True, exclude_dirs=True)
-        local_files["remote_path"] = "/" + local_files["path"]
-        local_files["remote_category"] = [
-            Path(p).parent.as_posix() for p in local_files["remote_path"]
-        ]
-        local_files["remote_category"] = local_files["remote_category"].astype(pd.StringDtype())
-        remote_files = self.list_files()
-
-        if delete_files:
-            to_delete = remote_files["path"].duplicated(keep="first") | ~remote_files[
-                "path"
-            ].isin(local_files["remote_path"])
-            if to_delete.any():
-                ids = ",".join(remote_files.loc[to_delete, "id"].astype(str))
-                params = {"ids": ids, "force": True}
-                self.post("file/delete.json", params=params)
-                remote_files = remote_files.loc[~to_delete, :]
-            # Empty recycle bin to release references before category deletion
-            self.post("file/empty_archive.json")
-
-        self.update_categories(
-            "file", target=local_files["remote_category"], delete=delete_categories
-        )
-        categories = self.list_categories("file")
-        category_map = dict(zip(categories["path"], categories["id"]))
-        category_map["/"] = None
-
-        if remote_files["path"].duplicated().any():
-            raise ValueError(
-                "Some remote files are duplicated. Either use mirror_files(..., delete_files=True) "
-                "or manually remove duplicates."
-            )
-        cols = {"path": "remote_path", "lastUpdated": "remote_modified_time"}
-        df = local_files.merge(
-            remote_files[["path", "lastUpdated", "id"]].rename(columns=cols),
-            on="remote_path",
-            how="left",
-        )
-        local_file_is_newer = (df["mtime"] > df["remote_modified_time"]).fillna(False)
-        to_update = df.loc[local_file_is_newer, :]
-        for local_file, remote_category, file_id in zip(
-            to_update["path"], to_update["remote_category"], to_update["id"]
-        ):
-            self.upload_file(
-                Path(directory) / local_file, category=category_map[remote_category], id=file_id
-            )
-
-        to_upload = local_files.loc[
-            ~local_files["remote_path"].isin(remote_files["path"]), :
-        ]
-        for local_file, remote_category in zip(
-            to_upload["path"], to_upload["remote_category"]
-        ):
-            self.upload_file(
-                Path(directory) / local_file, category=category_map[remote_category]
-            )
-
-    # ----------------------------------------------------------------------
-    # Tax Rates
-
-    def list_tax_rates(self) -> pd.DataFrame:
-        """List remote tax rates with their attributes.
-
-        Returns:
-            pd.DataFrame: A DataFrame with CashCtrlClient.TAX_COLUMNS schema.
-        """
-        tax_rates = pd.DataFrame(self.get("tax/list.json")["data"])
-        df = enforce_dtypes(tax_rates, TAX_COLUMNS)
-        return df.sort_values("name")
-
-    # ----------------------------------------------------------------------
-    # Accounts
-
-    def list_accounts(self) -> pd.DataFrame:
-        """List remote accounts with their attributes, and Unix-style path
-        representation of their hierarchical position in the category tree.
-
-        Returns:
-            pd.DataFrame: A DataFrame with CashCtrlClient.ACCOUNT_COLUMNS schema.
-        """
-        accounts = pd.DataFrame(self.get("account/list.json")["data"])
-        columns_except_path = {
-            key: value for key, value in ACCOUNT_COLUMNS.items() if key != "path"
-        }
-        df = enforce_dtypes(accounts, columns_except_path)
-        if len(df) > 0:
-            categories = self.list_categories("account", include_system=True)[["path", "id"]]
-            categories = categories.rename(columns={"id": "categoryId"})
-            df = df.merge(categories, on="categoryId", how="left")
-            df["path"] = df["path"].fillna("")
-        df = enforce_dtypes(df, ACCOUNT_COLUMNS)
-        return df.sort_values("number")
 
     # ----------------------------------------------------------------------
     # Categories
@@ -508,6 +296,218 @@ class CashCtrlClient:
                         params["number"] = target[category]
                     response = self.post(f"{resource}/category/create.json", params=params)
                     categories[node_path] = response["insertId"]
+
+    # ----------------------------------------------------------------------
+    # File Operations
+
+    def list_files(self) -> pd.DataFrame:
+        """List remote files with their attributes. Add the files' hierarchical
+        position in the category tree in Unix-like filepath format.
+
+        Returns:
+            pd.DataFrame: A DataFrame with CashCtrlClient.FILE_COLUMNS schema.
+        """
+        files = pd.DataFrame(self.get("file/list.json")["data"])
+        columns_except_path = {
+            key: value for key, value in FILE_COLUMNS.items() if key != "path"
+        }
+        df = enforce_dtypes(files, columns_except_path)
+        if len(df) > 0:
+            categories = self.list_categories("file")[["path", "id"]]
+            categories = categories.rename(columns={"id": "categoryId"})
+            df = df.merge(categories, on="categoryId", how="left")
+            df["path"] = df["path"].fillna("") + "/" + df["name"]
+        df = enforce_dtypes(df, FILE_COLUMNS)
+        return df.sort_values("path")
+
+    def upload_file(
+        self,
+        file: str | Path,
+        id: int | str | None = None,
+        name: str | None = None,
+        category: int | str | None = None,
+        mime_type: str | None = None,
+    ) -> int:
+        """Uploads a file to the server, marks it for persistent storage and,
+        if a remote file `id` is provided, replaces an existing file.
+
+        Args:
+            file (str | Path): Path to the local file to upload.
+            id (int | str | None, optional): ID of remote file to replace with new file.
+            name (str | None, optional): The filename on the remote server;
+                                         defaults to the local file's base name.
+            category (int | str | None, optional): ID of category the file is stored in.
+            mime_type (str | None, optional): The file's MIME type; guessed if not provided.
+
+        Returns:
+            int: The ID of the newly created or replaced file.
+
+        Raises:
+            FileNotFoundError: If the specified file does not exist.
+            ValueError: If the response does not contain exactly one file ID.
+            HTTPError: If the file upload fails.
+        """
+        path = Path(file).expanduser()
+        if not path.is_file():
+            raise FileNotFoundError(f"File not found: '{file}'")
+        files = [
+            {
+                "mimeType": (mime_type if mime_type is not None
+                             else guess_type(path)[0] or "text/plain"),
+                "name": name if name is not None else path.name,
+                "categoryId": category,
+            }
+        ]
+        response = self.post("file/prepare.json", params={"files": files})
+        if len(response["data"]) != 1:
+            raise ValueError("Expected response['data'] with length 1.")
+        new_file_id = response["data"][0]["fileId"]
+        write_url = response["data"][0]["writeUrl"]
+
+        with open(path, "rb") as file:
+            headers = {"Content-Type": "application/octet-stream"}
+            response = put(write_url, file, headers=headers, timeout=60)
+        if response.status_code != 200:
+            raise HTTPError(f"File upload failed: {response.reason}.")
+
+        if id is None:
+            self.post("file/persist.json", params={"ids": new_file_id})
+            return new_file_id
+        else:
+            params = {
+                "id": id,
+                "name": name if name is not None else path.name,
+                "replaceWith": new_file_id,
+                "categoryId": category,
+            }
+            self.post("file/update.json", params=params)
+            return int(id)
+
+    def download_file(self, id: int | str, path: str | Path):
+        """Downloads a file identified by a remote ID and saves it locally.
+
+        Args:
+            id (int | str): The remote file ID to download.
+            path (str | Path): Local path to save the downloaded file.
+        """
+        response = self.request("GET", endpoint="file/get", params={"id": id})
+        with open(Path(path).expanduser(), "wb") as file:
+            file.write(response.content)
+
+    def mirror_directory(
+        self,
+        directory: str | Path,
+        delete_files: bool = False,
+        delete_categories: bool = False,
+    ):
+        """Recursively mirrors a local directory on the CashCtrl server.
+
+        Ensures that the remote file system reflects the state of the local
+        directory, and that local sub-folders are mapped to remote categories.
+        The method creates, updates, and optionally deletes files and
+        categories (folders) on the server to match the local structure.
+
+        Args:
+            directory (str | Path): Path of the local directory to mirror.
+            delete_files (bool, optional): If True, deletes remote files without
+                                           a corresponding local file. Also empties
+                                           the recycle bin to release references
+                                           and allow for category deletion.
+            delete_categories (bool, optional): If True, deletes unused categories
+                                                (folders) on the server.
+        """
+        local_files = list_directory(directory, recursive=True, exclude_dirs=True)
+        local_files["remote_path"] = "/" + local_files["path"]
+        local_files["remote_category"] = [
+            Path(p).parent.as_posix() for p in local_files["remote_path"]
+        ]
+        local_files["remote_category"] = local_files["remote_category"].astype(pd.StringDtype())
+        remote_files = self.list_files()
+
+        if delete_files:
+            to_delete = remote_files["path"].duplicated(keep="first") | ~remote_files[
+                "path"
+            ].isin(local_files["remote_path"])
+            if to_delete.any():
+                ids = ",".join(remote_files.loc[to_delete, "id"].astype(str))
+                params = {"ids": ids, "force": True}
+                self.post("file/delete.json", params=params)
+                remote_files = remote_files.loc[~to_delete, :]
+            # Empty recycle bin to release references before category deletion
+            self.post("file/empty_archive.json")
+
+        self.update_categories(
+            "file", target=local_files["remote_category"], delete=delete_categories
+        )
+        categories = self.list_categories("file")
+        category_map = dict(zip(categories["path"], categories["id"]))
+        category_map["/"] = None
+
+        if remote_files["path"].duplicated().any():
+            raise ValueError(
+                "Some remote files are duplicated. Either use mirror_files(..., delete_files=True) "
+                "or manually remove duplicates."
+            )
+        cols = {"path": "remote_path", "lastUpdated": "remote_modified_time"}
+        df = local_files.merge(
+            remote_files[["path", "lastUpdated", "id"]].rename(columns=cols),
+            on="remote_path",
+            how="left",
+        )
+        local_file_is_newer = (df["mtime"] > df["remote_modified_time"]).fillna(False)
+        to_update = df.loc[local_file_is_newer, :]
+        for local_file, remote_category, file_id in zip(
+            to_update["path"], to_update["remote_category"], to_update["id"]
+        ):
+            self.upload_file(
+                Path(directory) / local_file, category=category_map[remote_category], id=file_id
+            )
+
+        to_upload = local_files.loc[
+            ~local_files["remote_path"].isin(remote_files["path"]), :
+        ]
+        for local_file, remote_category in zip(
+            to_upload["path"], to_upload["remote_category"]
+        ):
+            self.upload_file(
+                Path(directory) / local_file, category=category_map[remote_category]
+            )
+
+    # ----------------------------------------------------------------------
+    # Tax Rates
+
+    def list_tax_rates(self) -> pd.DataFrame:
+        """List remote tax rates with their attributes.
+
+        Returns:
+            pd.DataFrame: A DataFrame with CashCtrlClient.TAX_COLUMNS schema.
+        """
+        tax_rates = pd.DataFrame(self.get("tax/list.json")["data"])
+        df = enforce_dtypes(tax_rates, TAX_COLUMNS)
+        return df.sort_values("name")
+
+    # ----------------------------------------------------------------------
+    # Accounts
+
+    def list_accounts(self) -> pd.DataFrame:
+        """List remote accounts with their attributes, and Unix-style path
+        representation of their hierarchical position in the category tree.
+
+        Returns:
+            pd.DataFrame: A DataFrame with CashCtrlClient.ACCOUNT_COLUMNS schema.
+        """
+        accounts = pd.DataFrame(self.get("account/list.json")["data"])
+        columns_except_path = {
+            key: value for key, value in ACCOUNT_COLUMNS.items() if key != "path"
+        }
+        df = enforce_dtypes(accounts, columns_except_path)
+        if len(df) > 0:
+            categories = self.list_categories("account", include_system=True)[["path", "id"]]
+            categories = categories.rename(columns={"id": "categoryId"})
+            df = df.merge(categories, on="categoryId", how="left")
+            df["path"] = df["path"].fillna("")
+        df = enforce_dtypes(df, ACCOUNT_COLUMNS)
+        return df.sort_values("number")
 
     # ----------------------------------------------------------------------
     # Ledger

--- a/cashctrl_api/client.py
+++ b/cashctrl_api/client.py
@@ -41,7 +41,7 @@ class CashCtrlClient:
         self._base_url = f"https://{organisation}.cashctrl.com/api/v1"
 
     # ----------------------------------------------------------------------
-    # Helper Methods
+    # API Requests
 
     def request(
         self, method: str, endpoint: str, data: dict = None, params: dict = None
@@ -127,9 +127,6 @@ class CashCtrlClient:
                 msg = " / ".join(msg)
             raise RequestException(f"API call failed. {msg}")
         return result
-
-    # ----------------------------------------------------------------------
-    # API Requests
 
     def get(self, endpoint: str, data: dict = None, params: dict = None) -> dict:
         """Send GET request. See json_request for args and return value."""


### PR DESCRIPTION
## This pull request cover changes for implementing class navigation in large class definitions

### Here is logical groups that was created:

#### CashCtrlClient

1. **Constructors**
2. **Helper Methods**
3. **API Requests**
4. **File Operations**
5. **Tax Rates**
6. **Accounts**
7. **Categories**
8. **Ledger**

---

#### CachedCashCtrlClient

1. **Constructors**
2. **Helper Methods**
3. **API Requests**
4. **File Operations**
5. **Tax Rates**
6. **Accounts**
7. **Categories**
8. **Ledger**
9. **Cache Invalidation**

@lasuk Please review the changes and provide feedback or approval for merging.