### PR TITLE
Improve Directory Mirroring

### DIFF
--- a/cashctrl_api/client.py
+++ b/cashctrl_api/client.py
@@ -239,7 +239,7 @@ class CashCtrlClient:
         elif resource != "account" and isinstance(target, dict):
             raise ValueError("Target should be a list for resources other than 'account'.")
 
-        category_list = self.list_categories(resource, include_system=True)
+        category_list = self.list_categories(resource, include_system=(resource.lower() != "file"))
         categories = dict(zip(category_list["path"], category_list["id"]))
 
         if delete:


### PR DESCRIPTION
This PR is best rveviewed commit by commit. It contains two commits that are only loosely related:

- e7633f54 fixes an a bug which led to duplicate categories when mirroring a file system.
- e594d7fc extends rety-logic upon pacing error or connection failure to file uploads. It isolates the retry-mechanism in a new `request_with_retry` method and uses this method when uploading files.