### PR TITLE
Add fiscal period entity

### DIFF
--- a/cashctrl_api/client.py
+++ b/cashctrl_api/client.py
@@ -19,6 +19,7 @@ from .constants import (
     CATEGORY_COLUMNS,
     CURRENCY_COLUMNS,
     FILE_COLUMNS,
+    FISCAL_PERIOD_COLUMNS,
     JOURNAL_ENTRIES,
     PROFIT_CENTER_COLUMNS,
     TAX_COLUMNS
@@ -964,7 +965,7 @@ class CashCtrlClient:
         Returns:
             pd.DataFrame: A DataFrame with FISCAL_PERIOD_SCHEMA applied.
         """
-        fiscal_periods = pd.DataFrame(self._client.get("fiscalperiod/list.json")["data"])
+        fiscal_periods = pd.DataFrame(self.get("fiscalperiod/list.json")["data"])
         fiscal_periods = enforce_dtypes(fiscal_periods, FISCAL_PERIOD_COLUMNS)
         fp = fiscal_periods.sort_values("start").reset_index(drop=True)
 

--- a/cashctrl_api/client.py
+++ b/cashctrl_api/client.py
@@ -849,16 +849,22 @@ class CashCtrlClient:
     # Ledger
 
     @timed_cache(seconds=CACHE_TIMEOUT)
-    def list_journal_entries(self) -> pd.DataFrame:
+    def list_journal_entries(self, fiscal_period_id: int | None = None) -> pd.DataFrame:
         """List remote journal entries with their attributes.
 
+        Args:
+            fiscal_period_id (int | None, optional):
+                - If None (default), retrieves entries for the current fiscal period.
+                - If provided, retrieves entries for the specified fiscal period.
+
         Returns:
-            pd.DataFrame: A DataFrame with CashCtrlClient.ACCOUNT_COLUMNS schema.
+            pd.DataFrame: A DataFrame with CashCtrlClient.JOURNAL_ENTRIES schema.
         """
         # get("journal/list.json") returns by default the first 100 elements.
         # We override the size limit to download all values
         # https://app.cashctrl.com/static/help/en/api/index.html#/journal/list.json
-        response = self.get("journal/list.json", params={"limit": 999999999999999999})
+        params = {"limit": 999999999999999999, "fiscalPeriodId": fiscal_period_id}
+        response = self.get("journal/list.json", params=params)
         journal_entries = pd.DataFrame(response["data"])
         df = enforce_dtypes(journal_entries, JOURNAL_ENTRIES)
         return df.sort_values("dateAdded")

--- a/cashctrl_api/constants.py
+++ b/cashctrl_api/constants.py
@@ -188,8 +188,6 @@ FISCAL_PERIOD_COLUMNS = {
     "end": "datetime64[ns, Europe/Berlin]",
     "shortName": "string[python]",
     "lastEntryDate": "datetime64[ns, Europe/Berlin]",
-    "month": "bool",
-    "open": "bool",
     "isClosed": "bool",
     "isCurrent": "bool",
     "isTransient": "bool",

--- a/cashctrl_api/constants.py
+++ b/cashctrl_api/constants.py
@@ -177,4 +177,22 @@ CURRENCY_COLUMNS = {
     "isAuto": "bool",
 }
 
+FISCAL_PERIOD_COLUMNS = {
+    "id": "int",
+    "created": "datetime64[ns, Europe/Berlin]",
+    "createdBy": "string[python]",
+    "lastUpdated": "datetime64[ns, Europe/Berlin]",
+    "lastUpdatedBy": "string[python]",
+    "name": "string[python]",
+    "start": "datetime64[ns, Europe/Berlin]",
+    "end": "datetime64[ns, Europe/Berlin]",
+    "shortName": "string[python]",
+    "lastEntryDate": "datetime64[ns, Europe/Berlin]",
+    "month": "bool",
+    "open": "bool",
+    "isClosed": "bool",
+    "isCurrent": "bool",
+    "isTransient": "bool",
+}
+
 CACHE_TIMEOUT = 300

--- a/tests/test_fiscal_periods.py
+++ b/tests/test_fiscal_periods.py
@@ -1,0 +1,54 @@
+"""Unit tests for fiscal periods."""
+
+from cashctrl_api import CashCtrlClient
+import pandas as pd
+import pytest
+
+
+@pytest.fixture(scope="module")
+def cc_client() -> CashCtrlClient:
+    return CashCtrlClient()
+
+
+@pytest.fixture(scope="module")
+def fiscal_periods(cc_client):
+    # Explicitly call the base class method to circumvent the cache.
+    return CashCtrlClient.list_fiscal_periods(cc_client)
+
+
+def test_cached_fiscal_periods_same_to_actual(cc_client, fiscal_periods):
+    pd.testing.assert_frame_equal(cc_client.list_fiscal_periods(), fiscal_periods)
+
+
+def test_fiscal_period_from_id(cc_client, fiscal_periods):
+    assert (
+        cc_client.fiscal_period_from_id(fiscal_periods["id"].iat[0])
+        == fiscal_periods["name"].iat[0]
+    ), "Cached fiscal period name doesn't correspond to actual name"
+
+
+def test_fiscal_period_from_id_invalid_id_raises_error(cc_client):
+    with pytest.raises(ValueError, match="No fiscal period found for id"):
+        cc_client.fiscal_period_from_id(99999999)
+
+
+def test_fiscal_period_from_id_invalid_id_returns_none_with_allowed_missing(cc_client):
+    assert cc_client.fiscal_period_from_id(99999999, allow_missing=True) is None
+
+
+def test_fiscal_period_to_id(cc_client, fiscal_periods):
+    assert (
+        cc_client.fiscal_period_to_id(fiscal_periods["name"].iat[0])
+        == fiscal_periods["id"].iat[0]
+    ), "Cached fiscal period id doesn't correspond to actual id"
+
+
+def test_fiscal_period_to_id_with_invalid_fiscal_period_raises_error(cc_client):
+    with pytest.raises(ValueError, match="No id found for fiscal period"):
+        cc_client.fiscal_period_to_id("Nonexistent Period")
+
+
+def test_fiscal_period_to_id_with_invalid_fiscal_period_returns_none_with_allowed_missing(
+    cc_client
+):
+    assert cc_client.fiscal_period_to_id("Nonexistent Period", allow_missing=True) is None

--- a/tests/test_fiscal_periods.py
+++ b/tests/test_fiscal_periods.py
@@ -1,7 +1,6 @@
 """Unit tests for fiscal periods."""
 
 from cashctrl_api import CashCtrlClient
-import pandas as pd
 import pytest
 
 
@@ -10,21 +9,12 @@ def cc_client() -> CashCtrlClient:
     return CashCtrlClient()
 
 
-@pytest.fixture(scope="module")
-def fiscal_periods(cc_client):
-    # Explicitly call the base class method to circumvent the cache.
-    return CashCtrlClient.list_fiscal_periods(cc_client)
-
-
-def test_cached_fiscal_periods_same_to_actual(cc_client, fiscal_periods):
-    pd.testing.assert_frame_equal(cc_client.list_fiscal_periods(), fiscal_periods)
-
-
-def test_fiscal_period_from_id(cc_client, fiscal_periods):
+def test_fiscal_period_from_id(cc_client):
+    fiscal_periods = cc_client.list_fiscal_periods()
     assert (
         cc_client.fiscal_period_from_id(fiscal_periods["id"].iat[0])
         == fiscal_periods["name"].iat[0]
-    ), "Cached fiscal period name doesn't correspond to actual name"
+    ), "Mapped fiscal period name doesn't correspond to actual name"
 
 
 def test_fiscal_period_from_id_invalid_id_raises_error(cc_client):
@@ -36,11 +26,12 @@ def test_fiscal_period_from_id_invalid_id_returns_none_with_allowed_missing(cc_c
     assert cc_client.fiscal_period_from_id(99999999, allow_missing=True) is None
 
 
-def test_fiscal_period_to_id(cc_client, fiscal_periods):
+def test_fiscal_period_to_id(cc_client):
+    fiscal_periods = cc_client.list_fiscal_periods()
     assert (
         cc_client.fiscal_period_to_id(fiscal_periods["name"].iat[0])
         == fiscal_periods["id"].iat[0]
-    ), "Cached fiscal period id doesn't correspond to actual id"
+    ), "Mapped fiscal period id doesn't correspond to actual id"
 
 
 def test_fiscal_period_to_id_with_invalid_fiscal_period_raises_error(cc_client):


### PR DESCRIPTION
This PR goal is to define `list` and `mapper` methods for fiscal periods and add the `fiscal_period` parameter to the `list_journal_entries()` method