### PR TITLE
chore: bump GitHub Actions and pin third-party to SHA

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,12 +25,12 @@
 
       steps:
         - name: Check out repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
           with:
             ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
         - name: Set up Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v6
           with:
             python-version: "3.x"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         run: coverage run -m pytest -W error
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,12 +36,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -52,7 +52,7 @@ jobs:
         run: coverage run -m pytest -W error
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml


### PR DESCRIPTION
Bumps all GitHub Actions to latest major versions and pins the third-party `codecov/codecov-action` to a full commit SHA.

Per [GitHub security hardening guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), third-party actions should be pinned to a full commit SHA (not a mutable tag) to defend against supply-chain attacks.

## Changes

- `actions/checkout` v4 → v6
- `actions/setup-python` v4 → v6
- `codecov/codecov-action` v4 → v6, pinned to commit SHA `57e3a13`