### PR TITLE
Migrate GitHub org macxred → bluwat and update LICENSE holder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Follow these steps to set up your local development environment on Unix/Mac OS:
 2. **Clone the repository using SSH.**
     Ensure your SSH keys are set up on GitHub:
     ```bash
-    git clone git@github.com:macxred/cashctrl_api.git
+    git clone git@github.com:bluwat/cashctrl_api.git
     ```
 
 3. **Create a virtual development environment.**

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 MaCX ReD AG
+Copyright (c) 2024 Bluwat AG
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python Client for CashCtrl REST API
 
-[![codecov](https://codecov.io/gh/macxred/cashctrl_api/branch/main/graph/badge.svg)](https://codecov.io/gh/macxred/cashctrl_api)
+[![codecov](https://codecov.io/gh/bluwat/cashctrl_api/branch/main/graph/badge.svg)](https://codecov.io/gh/bluwat/cashctrl_api)
 
 `cashctrl_api` is a lightweight Python package that implements the
 CashCtrlClient class for interactions with the
@@ -67,7 +67,7 @@ The organization name and API key will be used to authenticate API requests.
 Easily install the package using pip:
 
 ```bash
-pip install https://github.com/macxred/cashctrl_api/tarball/main
+pip install https://github.com/bluwat/cashctrl_api/tarball/main
 ```
 
 

--- a/cashctrl_api/client.py
+++ b/cashctrl_api/client.py
@@ -31,7 +31,7 @@ from .list_directory import list_directory
 class CashCtrlClient:
     """A lightweight wrapper to interact with the CashCtrl REST API.
 
-    See README on https://github.com/macxred/cashctrl_api for overview and usage examples.
+    See README on https://github.com/bluwat/cashctrl_api for overview and usage examples.
     """
 
     # ----------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ setup(
     name="cashctrl_api",
     version="0.0.1",
     description="Python client for the CashCtrl REST API",
-    url="https://github.com/macxred/cashctrl_api",
+    url="https://github.com/bluwat/cashctrl_api",
     author="Lukas Elmiger",
     python_requires=">=3.9",
     install_requires=[
         "requests",
         "pandas",
-        "consistent_df @ https://github.com/macxred/consistent_df/tarball/main"
+        "consistent_df @ https://github.com/bluwat/consistent_df/tarball/main"
     ],
     packages=find_packages(exclude=("tests", "examples")),
     extras_require={


### PR DESCRIPTION
`cashctrl_api` moved from `macxred` to `bluwat`. Repoints every macxred reference (repo URL, codecov badge/link, pip install, CONTRIBUTING clone URL, `client.py` docstring, the `consistent_df` dependency URL) and updates the LICENSE holder to Bluwat AG.

Installs `consistent_df` (public) — no token needed. Integration tests use the existing CashCtrl secrets.